### PR TITLE
Adds missing check before publishing sensor data when in SvoMode

### DIFF
--- a/zed_components/src/zed_camera/src/zed_camera_component.cpp
+++ b/zed_components/src/zed_camera/src/zed_camera_component.cpp
@@ -3328,7 +3328,7 @@ void ZedCamera::callback_pubVideoDepth() {
 
     //RCLCPP_INFO_STREAM(get_logger(), "callback_pubVideoDepth - pub_ts type:" << pub_ts.get_clock_type());
 
-    if(mPublishingData && pub_ts!=TIMEZERO_ROS) {
+    if(mCamRealModel != sl::MODEL::ZED && mPublishingData && pub_ts!=TIMEZERO_ROS) {
         if(mSensCameraSync || mSvoMode) {
             publishSensorsData(pub_ts);
         }


### PR DESCRIPTION
**Summary**

This PR adds a missing `CamRealModel` check, that caused a segmentation fault when trying to publish sensor data to the uninitialized (=nullptr) `mPubImu` and `mPubImuRaw` publishers.

**Commits**
- [Fix] Fixes a bug when in SvoMode by adding a missing CamRealModel check before trying to publish sensor data.