### PR TITLE
[Fix] Skips processPose when returned LastZedPose quaternion is invalid.

### DIFF
--- a/zed_components/src/zed_camera/src/zed_camera_component.cpp
+++ b/zed_components/src/zed_camera/src/zed_camera_component.cpp
@@ -3773,6 +3773,10 @@ void ZedCamera::processPose() {
     sl::Translation translation = mLastZedPose.getTranslation();
     sl::Orientation quat = mLastZedPose.getOrientation();
 
+    if (quat.sum() == 0) {
+        return;
+    }
+
 #if 0 // Enable for TF checking
     double roll, pitch, yaw;
     tf2::Matrix3x3(tf2::Quaternion(quat.ox, quat.oy, quat.oz, quat.ow)).getRPY(roll, pitch, yaw);


### PR DESCRIPTION
I stumbled upon another issue when trying to run from an svo file using the flip mode to be set as `true`. In that case, inside the first call to `processPose` the returned pose is an invalid quaternion with all entries being zero. This leads to all the following `tf2::Transform` messages containing `nan` values. 

I, therefore, propose to add a check if the variable `quat` has all zero entries and return immediately if that is indeed the case. Another possibility would be to change the immediately following check to only contain `mPosTrackingStatus == sl::POSITIONAL_TRACKING_STATE::OK`. But I am not entirely sure if there is another reason why `mPosTrackingStatus == sl::POSITIONAL_TRACKING_STATE::SEARCHING` is also in there. 

Let me know what you guys think and if you can reproduce the error.