### PR TITLE
Remove redundant DIRECTORY keywords.

### DIFF
--- a/zed_components/CMakeLists.txt
+++ b/zed_components/CMakeLists.txt
@@ -159,8 +159,8 @@ install(TARGETS zed_camera_component
 # Install header files
 install(
     DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR}/src/zed_camera/include/
-    DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR}/src/tools/include/
-    DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR}/src/include/
+    ${CMAKE_CURRENT_SOURCE_DIR}/src/tools/include/
+    ${CMAKE_CURRENT_SOURCE_DIR}/src/include/
     DESTINATION include/${PROJECT_NAME}/
 )
 


### PR DESCRIPTION
They are parsed incorrectly by colcon and ros_cross_compile.