### PR TITLE
FIX typo in reliability qos2str conversion

### DIFF
--- a/zed_components/src/tools/src/sl_tools.cpp
+++ b/zed_components/src/tools/src/sl_tools.cpp
@@ -369,7 +369,7 @@ std::string qos2str(rmw_qos_reliability_policy_t qos) {
         return "RELIABLE";
     }
 
-    if (qos == RMW_QOS_POLICY_RELIABILITY_RELIABLE) {
+    if (qos == RMW_QOS_POLICY_RELIABILITY_BEST_EFFORT) {
         return "BEST_EFFORT";
     }
 


### PR DESCRIPTION
Setting RELIABLE reliability parameter would result in "Unknown QoS value" message. Now typo fixed