### PR TITLE
fixed subscriber counting, use image_transport functionality

### DIFF
--- a/zed_components/src/zed_camera/src/zed_camera_component.cpp
+++ b/zed_components/src/zed_camera/src/zed_camera_component.cpp
@@ -3473,21 +3473,21 @@ bool ZedCamera::publishVideoDepth( rclcpp::Time& out_pub_ts) {
     size_t disparitySubnumber = 0;
 
     try {
-        rgbSubnumber = count_subscribers(mPubRgb.getTopic());
-        rgbRawSubnumber = count_subscribers(mPubRawRgb.getTopic());
-        rgbGraySubnumber = count_subscribers(mPubRgbGray.getTopic());
-        rgbGrayRawSubnumber = count_subscribers(mPubRawRgbGray.getTopic());
-        leftSubnumber = count_subscribers(mPubLeft.getTopic());
-        leftRawSubnumber = count_subscribers(mPubRawLeft.getTopic());
-        leftGraySubnumber = count_subscribers(mPubLeftGray.getTopic());
-        leftGrayRawSubnumber = count_subscribers(mPubRawLeftGray.getTopic());
-        rightSubnumber = count_subscribers(mPubRight.getTopic());
-        rightRawSubnumber = count_subscribers(mPubRawRight.getTopic());
-        rightGraySubnumber = count_subscribers(mPubRightGray.getTopic());
-        rightGrayRawSubnumber = count_subscribers(mPubRawRightGray.getTopic());
-        stereoSubnumber = count_subscribers(mPubStereo.getTopic());
-        stereoRawSubnumber = count_subscribers(mPubRawStereo.getTopic());
-        depthSubnumber = count_subscribers(mPubDepth.getTopic());
+        rgbSubnumber = mPubRgb.getNumSubscribers();
+        rgbRawSubnumber = mPubRawRgb.getNumSubscribers();
+        rgbGraySubnumber = mPubRgbGray.getNumSubscribers();
+        rgbGrayRawSubnumber = mPubRawRgbGray.getNumSubscribers();
+        leftSubnumber = mPubLeft.getNumSubscribers();
+        leftRawSubnumber = mPubRawLeft.getNumSubscribers();
+        leftGraySubnumber = mPubLeftGray.getNumSubscribers();
+        leftGrayRawSubnumber = mPubRawLeftGray.getNumSubscribers();
+        rightSubnumber = mPubRight.getNumSubscribers();
+        rightRawSubnumber = mPubRawRight.getNumSubscribers();
+        rightGraySubnumber = mPubRightGray.getNumSubscribers();
+        rightGrayRawSubnumber = mPubRawRightGray.getNumSubscribers();
+        stereoSubnumber = mPubStereo.getNumSubscribers();
+        stereoRawSubnumber = mPubRawStereo.getNumSubscribers();
+        depthSubnumber = mPubDepth.getNumSubscribers();
         confMapSubnumber = count_subscribers(mPubConfMap->get_topic_name());
         disparitySubnumber = count_subscribers(mPubDisparity->get_topic_name());
     }


### PR DESCRIPTION
until now the driver uses the `rclcpp::Node::count_subscriber` function, which does not account for subscribtion to e.g. only `/image/compressed` topic.

The wrapper is currently not publishing the data, if one only subscribes to the compressed topic, as the count_subscriber function does not count subscribers to plugin topics. 

The function `image_transport::CameraPublisher::getNumSubscribers();` from the `image_transport` package should be used instead.
The functionality is available since `image_transport` dashing and should therefore not lead to issues.



