### PR TITLE
fix multiple DIRECTORY keywords

### DIFF
--- a/zed_components/CMakeLists.txt
+++ b/zed_components/CMakeLists.txt
@@ -155,10 +155,10 @@ install(TARGETS zed_camera_component
 )
 
 # Install header files
-install(
-    DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR}/src/zed_camera/include/
-    DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR}/src/tools/include/
-    DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR}/src/include/
+install(DIRECTORY 
+    ${CMAKE_CURRENT_SOURCE_DIR}/src/zed_camera/include/
+    ${CMAKE_CURRENT_SOURCE_DIR}/src/tools/include/
+    ${CMAKE_CURRENT_SOURCE_DIR}/src/include/
     DESTINATION include/${PROJECT_NAME}/
 )
 


### PR DESCRIPTION
To build some other packages, I had to upgrade CMake (CMake 3.21.1)

I then started getting build errors from zed2-ros-wrapper:

```
--- stderr: zed_components
CMake Error at cmake_install.cmake:69 (file):
  file INSTALL cannot find
  "/opt/zed/zed-ros2-wrapper/zed_components/DIRECTORY": No such file or
  directory.
```

It turns out it did not like multiple `DIRECTORY` statements in the one `install()` call in CMakeLists.txt
https://cmake.org/cmake/help/latest/command/install.html#directory
