### PR TITLE
Fixed CMake DIRECTORY error

### DIFF
--- a/zed_components/CMakeLists.txt
+++ b/zed_components/CMakeLists.txt
@@ -158,9 +158,10 @@ install(TARGETS zed_camera_component
 
 # Install header files
 install(
-    DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR}/src/zed_camera/include/
-    DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR}/src/tools/include/
-    DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR}/src/include/
+    DIRECTORY 
+      ${CMAKE_CURRENT_SOURCE_DIR}/src/zed_camera/include/
+      ${CMAKE_CURRENT_SOURCE_DIR}/src/tools/include/
+      ${CMAKE_CURRENT_SOURCE_DIR}/src/include/
     DESTINATION include/${PROJECT_NAME}/
 )
 


### PR DESCRIPTION
The proposed change makes the eloquent branch look like the master branch on these lines. Looks like this has been fixed previously, but only on master. (https://github.com/stereolabs/zed-ros2-wrapper/pull/49)