### PR TITLE
Fix performance drop when platform is slower to retrieve images w.r.t. requested rate

### DIFF
--- a/zed_components/src/zed_camera/include/zed_camera_component.hpp
+++ b/zed_components/src/zed_camera/include/zed_camera_component.hpp
@@ -585,17 +585,6 @@ private:
     const std::string mSrvStopSvoRecName = "stop_svo_rec";
     const std::string mSrvToggleSvoPauseName = "toggle_svo_pause";
     // <---- Services names
-
-    sl::Mat mat_left,mat_left_raw;
-    sl::Mat mat_right,mat_right_raw;
-    sl::Mat mat_left_gray,mat_left_raw_gray;
-    sl::Mat mat_right_gray,mat_right_raw_gray;
-    sl::Mat mat_depth,mat_disp,mat_conf;
-    sl::Timestamp ts_rgb=0;       // used to check RGB/Depth sync
-    sl::Timestamp ts_depth=0;     // used to check RGB/Depth sync
-    sl::Timestamp grab_ts=0;
-    rclcpp::Time timeStamp;
-
 };
 
 } // namespace stereolabs

--- a/zed_components/src/zed_camera/include/zed_camera_component.hpp
+++ b/zed_components/src/zed_camera/include/zed_camera_component.hpp
@@ -35,15 +35,11 @@
 #include <tf2_ros/transform_listener.h>
 #include <tf2_ros/transform_broadcaster.h>
 #include <tf2_ros/static_transform_broadcaster.h>
-
-#include <diagnostic_updater/diagnostic_updater.hpp>
-#include <diagnostic_msgs/msg/diagnostic_status.hpp>
-
 #include <geometry_msgs/msg/pose_stamped.hpp>
 #include <geometry_msgs/msg/pose_with_covariance_stamped.hpp>
-#include <image_transport/image_transport.hpp>
-#include <image_transport/camera_publisher.hpp>
-#include <image_transport/publisher.hpp>
+#include <image_transport/image_transport.h>
+#include <image_transport/camera_publisher.h>
+#include <image_transport/publisher.h>
 #include <stereo_msgs/msg/disparity_image.hpp>
 #include <sensor_msgs/msg/camera_info.hpp>
 #include <sensor_msgs/msg/point_cloud2.hpp>
@@ -70,6 +66,7 @@
 namespace stereolabs {
 
 // ----> Typedefs to simplify declarations
+
 typedef std::shared_ptr<rclcpp::Publisher<sensor_msgs::msg::Image>> imagePub;
 typedef std::shared_ptr<rclcpp::Publisher<stereo_msgs::msg::DisparityImage>> disparityPub;
 
@@ -129,7 +126,6 @@ protected:
     void initParameters();
     void initServices();
 
-    void getDebugParams();
     void getGeneralParams();
     void getVideoParams();
     void getDepthParams();
@@ -161,7 +157,6 @@ protected:
     void callback_pubFusedPc();
     void callback_pubPaths();
     rcl_interfaces::msg::SetParametersResult callback_paramChange(std::vector<rclcpp::Parameter> parameters);
-    void callback_updateDiagnostic(diagnostic_updater::DiagnosticStatusWrapper& stat);
 
     void callback_resetOdometry(const std::shared_ptr<rmw_request_id_t> request_header,
                                 const std::shared_ptr<std_srvs::srv::Trigger_Request> req,
@@ -187,7 +182,6 @@ protected:
     void callback_pauseSvoInput(const std::shared_ptr<rmw_request_id_t> request_header,
                                 const std::shared_ptr<std_srvs::srv::Trigger_Request> req,
                                 std::shared_ptr<std_srvs::srv::Trigger_Response> res);
-
     // <---- Callbacks
 
     // ----> Thread functions
@@ -278,7 +272,6 @@ private:
     int mGpuId = -1;
     sl::RESOLUTION mCamResol = sl::RESOLUTION::HD720;           // Default resolution: RESOLUTION_HD720
     sl::DEPTH_MODE mDepthQuality = sl::DEPTH_MODE::PERFORMANCE; // Default depth mode: DEPTH_MODE_PERFORMANCE
-    bool mDepthDisabled=false; // Indicates if depth calculation is not required (DEPTH_MODE::NONE se for )
     bool mDepthStabilization = true;
     int mCamTimeoutSec = 5;
     int mMaxReconnectTemp = 5;
@@ -349,6 +342,7 @@ private:
     int mDepthConf = 50;
     int mDepthTextConf = 100;
     double mDepthDownsampleFactor = 1.0;
+    double mDepthPubRate = 15.0;
     double mPcPubRate = 15.0;
     double mFusedPcPubRate = 1.0;
     // <---- Dynamic params
@@ -486,7 +480,7 @@ private:
 
     // ----> Thread Sync
     std::mutex mCloseZedMutex;
-    std::mutex mCamDataMutex;
+    std::timed_mutex mCamDataMutex;
     std::mutex mPcMutex;
     std::mutex mRecMutex;
     std::mutex mPosTrkMutex;
@@ -495,7 +489,7 @@ private:
     std::mutex mObjDetMutex;
     std::condition_variable mPcDataReadyCondVar;
     bool mPcDataReady=false;
-    std::condition_variable mRgbDepthDataRetrievedCondVar;
+    std::condition_variable_any mRgbDepthDataRetrievedCondVar;
     bool mRgbDepthDataRetrieved=true;
     // <---- Thread Sync
 
@@ -509,7 +503,8 @@ private:
     bool mTriggerAutoWB = true;         // Triggered on start
     bool mStaticImuTopicPublished = false;
     bool mRecording=false;
-    sl::RecordingStatus mRecStatus = sl::RecordingStatus();
+    //sl::RecordingStatus mRecStatus = sl::RecordingStatus(); // TODO replace when fixed in SDK
+    bool mRecStatus = false;
     bool mPosTrackingReady=false;
     sl::POSITIONAL_TRACKING_STATE mPosTrackingStatus;
     bool mResetOdom=false;
@@ -528,23 +523,14 @@ private:
     float mTempLeft = -273.15f;
     float mTempRight = -273.15f;
     std::unique_ptr<sl_tools::SmartMean> mElabPeriodMean_sec;
-    std::unique_ptr<sl_tools::SmartMean> mGrabPeriodMean_sec;
+    std::unique_ptr<sl_tools::SmartMean> mGrabPeriodMean_usec;
     std::unique_ptr<sl_tools::SmartMean> mVideoDepthPeriodMean_sec;
-    std::unique_ptr<sl_tools::SmartMean> mVideoDepthElabMean_sec;
-    std::unique_ptr<sl_tools::SmartMean> mPcPeriodMean_sec;
-    std::unique_ptr<sl_tools::SmartMean> mPcProcMean_sec;
-    std::unique_ptr<sl_tools::SmartMean> mImuPeriodMean_sec;
-    std::unique_ptr<sl_tools::SmartMean> mBaroPeriodMean_sec;
-    std::unique_ptr<sl_tools::SmartMean> mMagPeriodMean_sec;
-    std::unique_ptr<sl_tools::SmartMean> mObjDetPeriodMean_sec;
-    std::unique_ptr<sl_tools::SmartMean> mObjDetElabMean_sec;
+    std::unique_ptr<sl_tools::SmartMean> mPcPeriodMean_usec;
+    std::unique_ptr<sl_tools::SmartMean> mImuPeriodMean_usec;
+    std::unique_ptr<sl_tools::SmartMean> mBaroPeriodMean_usec;
+    std::unique_ptr<sl_tools::SmartMean> mMagPeriodMean_usec;
+    std::unique_ptr<sl_tools::SmartMean> mObjDetPeriodMean_msec;
     std::unique_ptr<sl_tools::SmartMean> mPubFusedCloudPeriodMean_sec;
-    bool mImuPublishing=false;
-    bool mMagPublishing=false;
-    bool mBaroPublishing=false;
-    bool mObjDetSubscribed=false;
-
-    diagnostic_updater::Updater mDiagUpdater;  // Diagnostic Updater
 
     // ----> Timestamps
     rclcpp::Time mFrameTimestamp;
@@ -584,6 +570,17 @@ private:
     const std::string mSrvStopSvoRecName = "stop_svo_rec";
     const std::string mSrvToggleSvoPauseName = "toggle_svo_pause";
     // <---- Services names
+
+    sl::Mat mat_left,mat_left_raw;
+    sl::Mat mat_right,mat_right_raw;
+    sl::Mat mat_left_gray,mat_left_raw_gray;
+    sl::Mat mat_right_gray,mat_right_raw_gray;
+    sl::Mat mat_depth,mat_disp,mat_conf;
+    sl::Timestamp ts_rgb=0;       // used to check RGB/Depth sync
+    sl::Timestamp ts_depth=0;     // used to check RGB/Depth sync
+    sl::Timestamp grab_ts=0;
+    rclcpp::Time timeStamp;
+
 };
 
 } // namespace stereolabs

--- a/zed_components/src/zed_camera/src/zed_camera_component.cpp
+++ b/zed_components/src/zed_camera/src/zed_camera_component.cpp
@@ -4043,9 +4043,15 @@ bool ZedCamera::publishVideoDepth(rclcpp::Time& out_pub_ts)
 
   bool retrieved = false;
 
-  ts_rgb = 0;    // used to check RGB/Depth sync
-  ts_depth = 0;  // used to check RGB/Depth sync
-  grab_ts = 0;
+  static sl::Mat mat_left,mat_left_raw;
+  static sl::Mat mat_right,mat_right_raw;
+  static sl::Mat mat_left_gray,mat_left_raw_gray;
+  static sl::Mat mat_right_gray,mat_right_raw_gray;
+  static sl::Mat mat_depth,mat_disp,mat_conf;
+
+  static sl::Timestamp ts_rgb=0;       // used to check RGB/Depth sync
+  static sl::Timestamp ts_depth=0;     // used to check RGB/Depth sync
+  static sl::Timestamp grab_ts=0;
 
   // ----> Retrieve all required data
   std::unique_lock<std::timed_mutex> lock(mCamDataMutex, std::defer_lock);
@@ -4155,6 +4161,7 @@ bool ZedCamera::publishVideoDepth(rclcpp::Time& out_pub_ts)
   lastZedTs = grab_ts;
   // <---- Check if a grab has been done before publishing the same images
 
+  static rclcpp::Time timeStamp;
   if (!mSvoMode)
   {
     timeStamp = sl_tools::slTime2Ros(grab_ts, get_clock()->get_clock_type());

--- a/zed_components/src/zed_camera/src/zed_camera_component.cpp
+++ b/zed_components/src/zed_camera/src/zed_camera_component.cpp
@@ -3173,7 +3173,7 @@ void ZedCamera::threadFunc_zedGrab()
     // ----> Check for Object Detection requirement
 
     // ----> Wait for RGB/Depth synchronization before grabbing
-    std::unique_lock<std::mutex> datalock(mCamDataMutex);
+    std::unique_lock<std::timed_mutex> datalock(mCamDataMutex);
     while (!mRgbDepthDataRetrieved)
     {  // loop to avoid spurious wakeups
       if (mRgbDepthDataRetrievedCondVar.wait_for(datalock, std::chrono::milliseconds(500)) == std::cv_status::timeout)
@@ -3996,23 +3996,23 @@ bool ZedCamera::publishVideoDepth(rclcpp::Time& out_pub_ts)
 
   static sl::Timestamp lastZedTs = 0;  // Used to calculate stable publish frequency
 
-  size_t rgbSubnumber = 0;
-  size_t rgbRawSubnumber = 0;
-  size_t rgbGraySubnumber = 0;
-  size_t rgbGrayRawSubnumber = 0;
-  size_t leftSubnumber = 0;
-  size_t leftRawSubnumber = 0;
-  size_t leftGraySubnumber = 0;
-  size_t leftGrayRawSubnumber = 0;
-  size_t rightSubnumber = 0;
-  size_t rightRawSubnumber = 0;
-  size_t rightGraySubnumber = 0;
-  size_t rightGrayRawSubnumber = 0;
-  size_t stereoSubnumber = 0;
-  size_t stereoRawSubnumber = 0;
-  size_t depthSubnumber = 0;
-  size_t confMapSubnumber = 0;
-  size_t disparitySubnumber = 0;
+  static size_t rgbSubnumber = 0;
+  static size_t rgbRawSubnumber = 0;
+  static size_t rgbGraySubnumber = 0;
+  static size_t rgbGrayRawSubnumber = 0;
+  static size_t leftSubnumber = 0;
+  static size_t leftRawSubnumber = 0;
+  static size_t leftGraySubnumber = 0;
+  static size_t leftGrayRawSubnumber = 0;
+  static size_t rightSubnumber = 0;
+  static size_t rightRawSubnumber = 0;
+  static size_t rightGraySubnumber = 0;
+  static size_t rightGrayRawSubnumber = 0;
+  static size_t stereoSubnumber = 0;
+  static size_t stereoRawSubnumber = 0;
+  static size_t depthSubnumber = 0;
+  static size_t confMapSubnumber = 0;
+  static size_t disparitySubnumber = 0;
 
   try
   {
@@ -4043,74 +4043,59 @@ bool ZedCamera::publishVideoDepth(rclcpp::Time& out_pub_ts)
 
   bool retrieved = false;
 
-  sl::Mat mat_left, mat_left_raw;
-  sl::Mat mat_right, mat_right_raw;
-  sl::Mat mat_left_gray, mat_left_raw_gray;
-  sl::Mat mat_right_gray, mat_right_raw_gray;
-  sl::Mat mat_depth, mat_disp, mat_conf;
-
-  sl::Timestamp ts_rgb = 0;    // used to check RGB/Depth sync
-  sl::Timestamp ts_depth = 0;  // used to check RGB/Depth sync
-  sl::Timestamp grab_ts = 0;
+  ts_rgb = 0;    // used to check RGB/Depth sync
+  ts_depth = 0;  // used to check RGB/Depth sync
+  grab_ts = 0;
 
   // ----> Retrieve all required data
-  std::unique_lock<std::mutex> lock(mCamDataMutex, std::defer_lock);
+  std::unique_lock<std::timed_mutex> lock(mCamDataMutex, std::defer_lock);
 
-  if (lock.try_lock())
+  if (lock.try_lock_for(std::chrono::milliseconds(1000/mCamGrabFrameRate)))
   {
     if (rgbSubnumber + leftSubnumber + stereoSubnumber > 0)
     {
-      mZed.retrieveImage(mat_left, sl::VIEW::LEFT, sl::MEM::CPU, mMatResolVideo);
-      retrieved = true;
+      retrieved = sl::ERROR_CODE::SUCCESS ==  mZed.retrieveImage(mat_left, sl::VIEW::LEFT, sl::MEM::CPU, mMatResolVideo);
       ts_rgb = mat_left.timestamp;
       grab_ts = mat_left.timestamp;
     }
     if (rgbRawSubnumber + leftRawSubnumber + stereoRawSubnumber > 0)
     {
-      mZed.retrieveImage(mat_left_raw, sl::VIEW::LEFT_UNRECTIFIED, sl::MEM::CPU, mMatResolVideo);
-      retrieved = true;
+      retrieved = sl::ERROR_CODE::SUCCESS ==  mZed.retrieveImage(mat_left_raw, sl::VIEW::LEFT_UNRECTIFIED, sl::MEM::CPU, mMatResolVideo);
       grab_ts = mat_left_raw.timestamp;
     }
     if (rightSubnumber + stereoSubnumber > 0)
     {
-      mZed.retrieveImage(mat_right, sl::VIEW::RIGHT, sl::MEM::CPU, mMatResolVideo);
-      retrieved = true;
+      retrieved = sl::ERROR_CODE::SUCCESS ==  mZed.retrieveImage(mat_right, sl::VIEW::RIGHT, sl::MEM::CPU, mMatResolVideo);
       grab_ts = mat_right.timestamp;
     }
     if (rightRawSubnumber + stereoRawSubnumber > 0)
     {
-      mZed.retrieveImage(mat_right_raw, sl::VIEW::RIGHT_UNRECTIFIED, sl::MEM::CPU, mMatResolVideo);
-      retrieved = true;
+      retrieved = sl::ERROR_CODE::SUCCESS ==  mZed.retrieveImage(mat_right_raw, sl::VIEW::RIGHT_UNRECTIFIED, sl::MEM::CPU, mMatResolVideo);
       grab_ts = mat_right_raw.timestamp;
     }
     if (rgbGraySubnumber + leftGraySubnumber > 0)
     {
-      mZed.retrieveImage(mat_left_gray, sl::VIEW::LEFT_GRAY, sl::MEM::CPU, mMatResolVideo);
-      retrieved = true;
+      retrieved = sl::ERROR_CODE::SUCCESS ==  mZed.retrieveImage(mat_left_gray, sl::VIEW::LEFT_GRAY, sl::MEM::CPU, mMatResolVideo);
       grab_ts = mat_left_gray.timestamp;
     }
     if (rgbGrayRawSubnumber + leftGrayRawSubnumber > 0)
     {
-      mZed.retrieveImage(mat_left_raw_gray, sl::VIEW::LEFT_UNRECTIFIED_GRAY, sl::MEM::CPU, mMatResolVideo);
-      retrieved = true;
+      retrieved = sl::ERROR_CODE::SUCCESS ==  mZed.retrieveImage(mat_left_raw_gray, sl::VIEW::LEFT_UNRECTIFIED_GRAY, sl::MEM::CPU, mMatResolVideo);
       grab_ts = mat_left_raw_gray.timestamp;
     }
     if (rightGraySubnumber > 0)
     {
-      mZed.retrieveImage(mat_right_gray, sl::VIEW::RIGHT_GRAY, sl::MEM::CPU, mMatResolVideo);
-      retrieved = true;
+      retrieved = sl::ERROR_CODE::SUCCESS ==  mZed.retrieveImage(mat_right_gray, sl::VIEW::RIGHT_GRAY, sl::MEM::CPU, mMatResolVideo);
       grab_ts = mat_right_gray.timestamp;
     }
     if (rightGrayRawSubnumber > 0)
     {
-      mZed.retrieveImage(mat_right_raw_gray, sl::VIEW::RIGHT_UNRECTIFIED_GRAY, sl::MEM::CPU, mMatResolVideo);
-      retrieved = true;
+      retrieved = sl::ERROR_CODE::SUCCESS ==  mZed.retrieveImage(mat_right_raw_gray, sl::VIEW::RIGHT_UNRECTIFIED_GRAY, sl::MEM::CPU, mMatResolVideo);
       grab_ts = mat_right_raw_gray.timestamp;
     }
     if (depthSubnumber > 0)
     {
-      mZed.retrieveMeasure(mat_depth, sl::MEASURE::DEPTH, sl::MEM::CPU, mMatResolDepth);
-      retrieved = true;
+      retrieved = sl::ERROR_CODE::SUCCESS ==  mZed.retrieveMeasure(mat_depth, sl::MEASURE::DEPTH, sl::MEM::CPU, mMatResolDepth);
       grab_ts = mat_depth.timestamp;
 
       ts_depth = mat_depth.timestamp;
@@ -4123,16 +4108,16 @@ bool ZedCamera::publishVideoDepth(rclcpp::Time& out_pub_ts)
     }
     if (disparitySubnumber > 0)
     {
-      mZed.retrieveMeasure(mat_disp, sl::MEASURE::DISPARITY, sl::MEM::CPU, mMatResolDepth);
-      retrieved = true;
+      retrieved = sl::ERROR_CODE::SUCCESS ==  mZed.retrieveMeasure(mat_disp, sl::MEASURE::DISPARITY, sl::MEM::CPU, mMatResolDepth);
       grab_ts = mat_disp.timestamp;
     }
     if (confMapSubnumber > 0)
     {
-      mZed.retrieveMeasure(mat_conf, sl::MEASURE::CONFIDENCE, sl::MEM::CPU, mMatResolDepth);
-      retrieved = true;
+      retrieved = sl::ERROR_CODE::SUCCESS ==  mZed.retrieveMeasure(mat_conf, sl::MEASURE::CONFIDENCE, sl::MEM::CPU, mMatResolDepth);
       grab_ts = mat_conf.timestamp;
     }
+  } else {
+    RCLCPP_INFO(get_logger(), "Lock timeout");
   }
   // <---- Retrieve all required data
 
@@ -4170,7 +4155,6 @@ bool ZedCamera::publishVideoDepth(rclcpp::Time& out_pub_ts)
   lastZedTs = grab_ts;
   // <---- Check if a grab has been done before publishing the same images
 
-  rclcpp::Time timeStamp;
   if (!mSvoMode)
   {
     timeStamp = sl_tools::slTime2Ros(grab_ts, get_clock()->get_clock_type());


### PR DESCRIPTION
Whenever `pub_frame_rate` was higher than a certain threshold (5.0 Hz on our Jetson Nano) setting a greater value (like 6.0 or higher) resulted in a sudden drop of framerate from 5 Hz to 1.3 Hz at most.

This patch changes the behaviour that in case of locked mutex skipped the publication of newest frames, skipping a timer tick. Mutex is waited for at most a grab cycle, as the grab cycle is the only other user of that mutex and runs at higher frequency.