### PR TITLE
[Feature] Default xacro path in zed_camera.launch.py

### DIFF
--- a/zed_wrapper/launch/include/zed_camera.launch.py
+++ b/zed_wrapper/launch/include/zed_camera.launch.py
@@ -44,6 +44,13 @@ def generate_launch_description():
         'common.yaml'
     )
 
+    # URDF/xacro file to be loaded by the Robot State Publisher node
+    default_xacro_path = os.path.join(
+        get_package_share_directory('zed_wrapper'),
+        'urdf',
+        'zed_descr.urdf.xacro'
+    )
+
     # Declare the launch arguments
     declare_camera_name_cmd = DeclareLaunchArgument(
         'camera_name',
@@ -74,6 +81,7 @@ def generate_launch_description():
 
     declare_xacro_path_cmd = DeclareLaunchArgument(
         'xacro_path',
+        default_value=default_xacro_path,
         description='Path to the camera URDF file as a xacro file.')
 
     declare_svo_path_cmd = DeclareLaunchArgument(


### PR DESCRIPTION
Using the `zed_camera.launch.py` directly as launch file, makes it very convenient to specify certain parameters directly at launch time.

However, making the `xacro_path` a parameter without a default value, complicates the launch process. 
A default value (e.g. like the one used for the `config_common_path`) would be much more appropriate.

This PR adds this `default_xacro_path` to the `zed_camera.launch.py`