### PR TITLE
Override `general.camera_name` parameter with launch argument

### DIFF
--- a/zed_wrapper/launch/include/zed_camera.launch.py
+++ b/zed_wrapper/launch/include/zed_camera.launch.py
@@ -166,6 +166,7 @@ def generate_launch_description():
             # Overriding
             {
                 'general.camera_name': camera_name,
+                'general.camera_model': camera_model,
                 'general.svo_file': svo_path,
                 'pos_tracking.base_frame': base_frame
             }

--- a/zed_wrapper/launch/include/zed_camera.launch.py
+++ b/zed_wrapper/launch/include/zed_camera.launch.py
@@ -165,6 +165,7 @@ def generate_launch_description():
             config_camera_path,  # Camera related parameters
             # Overriding
             {
+                'general.camera_name': camera_name,
                 'general.svo_file': svo_path,
                 'pos_tracking.base_frame': base_frame
             }


### PR DESCRIPTION
Fixes #71.