### PR TITLE
Set read_only flag in parameter descriptors for non-dynamic parameters

### DIFF
--- a/zed_components/src/zed_camera/include/zed_camera_component.hpp
+++ b/zed_components/src/zed_camera/include/zed_camera_component.hpp
@@ -253,7 +253,7 @@ protected:
     void startPathPubTimer(double pathTimerRate);
 
     template <typename T>
-    void getParam(std::string paramName, T defValue, T& outVal, std::string log_info = std::string());
+    void getParam(std::string paramName, T defValue, T& outVal, std::string log_info = std::string(), bool dynamic = false);
     // <---- Utility functions
 
 private:

--- a/zed_components/src/zed_camera/src/zed_camera_component.cpp
+++ b/zed_components/src/zed_camera/src/zed_camera_component.cpp
@@ -435,6 +435,8 @@ void ZedCamera::getVideoParams()
     int qos_depth = 1;
     rmw_qos_reliability_policy_t qos_reliability = RMW_QOS_POLICY_RELIABILITY_RELIABLE;
     rmw_qos_durability_policy_t qos_durability = RMW_QOS_POLICY_DURABILITY_VOLATILE;
+    rcl_interfaces::msg::ParameterDescriptor read_only_descriptor;
+    read_only_descriptor.read_only = true;
 
     getParam("video.extrinsic_in_camera_frame",
         mUseOldExtrinsic,
@@ -442,7 +444,7 @@ void ZedCamera::getVideoParams()
         " * Use old extrinsic parameters: ");
 
     getParam(
-        "video.img_downsample_factor", mImgDownsampleFactor, mImgDownsampleFactor);
+        "video.img_downsample_factor", mImgDownsampleFactor, mImgDownsampleFactor, "", true);
     if (mImgDownsampleFactor < 0.1) {
         mImgDownsampleFactor = 0.1;
         RCLCPP_WARN(get_logger(),
@@ -500,7 +502,7 @@ void ZedCamera::getVideoParams()
     // ------------------------------------------
 
     paramName = "video.qos_history";
-    declare_parameter(paramName, rclcpp::ParameterValue(qos_hist));
+    declare_parameter(paramName, rclcpp::ParameterValue(qos_hist), read_only_descriptor);
 
     if (get_parameter(paramName, paramVal)) {
         qos_hist = paramVal.as_int() == 1 ? RMW_QOS_POLICY_HISTORY_KEEP_LAST
@@ -519,7 +521,7 @@ void ZedCamera::getVideoParams()
     // ------------------------------------------
 
     paramName = "video.qos_depth";
-    declare_parameter(paramName, rclcpp::ParameterValue(qos_depth));
+    declare_parameter(paramName, rclcpp::ParameterValue(qos_depth), read_only_descriptor);
 
     if (get_parameter(paramName, paramVal)) {
         qos_depth = paramVal.as_int();
@@ -535,7 +537,7 @@ void ZedCamera::getVideoParams()
     // ------------------------------------------
 
     paramName = "video.qos_reliability";
-    declare_parameter(paramName, rclcpp::ParameterValue(qos_reliability));
+    declare_parameter(paramName, rclcpp::ParameterValue(qos_reliability), read_only_descriptor);
 
     if (get_parameter(paramName, paramVal)) {
         qos_reliability = paramVal.as_int() == 1
@@ -556,7 +558,7 @@ void ZedCamera::getVideoParams()
     // ------------------------------------------
 
     paramName = "video.qos_durability";
-    declare_parameter(paramName, rclcpp::ParameterValue(qos_durability));
+    declare_parameter(paramName, rclcpp::ParameterValue(qos_durability), read_only_descriptor);
 
     if (get_parameter(paramName, paramVal)) {
         qos_durability = paramVal.as_int() == 0
@@ -583,6 +585,8 @@ void ZedCamera::getDepthParams()
     int qos_depth = 1;
     rmw_qos_reliability_policy_t qos_reliability = RMW_QOS_POLICY_RELIABILITY_RELIABLE;
     rmw_qos_durability_policy_t qos_durability = RMW_QOS_POLICY_DURABILITY_VOLATILE;
+    rcl_interfaces::msg::ParameterDescriptor read_only_descriptor;
+    read_only_descriptor.read_only = true;
 
     RCLCPP_INFO(get_logger(), "*** DEPTH parameters ***");
 
@@ -669,7 +673,7 @@ void ZedCamera::getDepthParams()
         // ------------------------------------------
 
         paramName = "depth.qos_history";
-        declare_parameter(paramName, rclcpp::ParameterValue(qos_hist));
+        declare_parameter(paramName, rclcpp::ParameterValue(qos_hist), read_only_descriptor);
 
         if (get_parameter(paramName, paramVal)) {
             qos_hist = paramVal.as_int() == 1 ? RMW_QOS_POLICY_HISTORY_KEEP_LAST
@@ -689,7 +693,7 @@ void ZedCamera::getDepthParams()
         // ------------------------------------------
 
         paramName = "depth.qos_depth";
-        declare_parameter(paramName, rclcpp::ParameterValue(qos_depth));
+        declare_parameter(paramName, rclcpp::ParameterValue(qos_depth), read_only_descriptor);
 
         if (get_parameter(paramName, paramVal)) {
             qos_depth = paramVal.as_int();
@@ -706,7 +710,7 @@ void ZedCamera::getDepthParams()
         // ------------------------------------------
 
         paramName = "depth.qos_reliability";
-        declare_parameter(paramName, rclcpp::ParameterValue(qos_reliability));
+        declare_parameter(paramName, rclcpp::ParameterValue(qos_reliability), read_only_descriptor);
 
         if (get_parameter(paramName, paramVal)) {
             qos_reliability = paramVal.as_int() == 1
@@ -727,7 +731,7 @@ void ZedCamera::getDepthParams()
         // ------------------------------------------
 
         paramName = "depth.qos_durability";
-        declare_parameter(paramName, rclcpp::ParameterValue(qos_durability));
+        declare_parameter(paramName, rclcpp::ParameterValue(qos_durability), read_only_descriptor);
 
         if (get_parameter(paramName, paramVal)) {
             qos_durability = paramVal.as_int() == 1
@@ -756,6 +760,8 @@ void ZedCamera::getSensorsParams()
     int qos_depth = 1;
     rmw_qos_reliability_policy_t qos_reliability = RMW_QOS_POLICY_RELIABILITY_RELIABLE;
     rmw_qos_durability_policy_t qos_durability = RMW_QOS_POLICY_DURABILITY_VOLATILE;
+    rcl_interfaces::msg::ParameterDescriptor read_only_descriptor;
+    read_only_descriptor.read_only = true;
 
     RCLCPP_INFO(get_logger(), "*** SENSORS STACK parameters ***");
     if (mCamUserModel == sl::MODEL::ZED) {
@@ -778,7 +784,7 @@ void ZedCamera::getSensorsParams()
     // ------------------------------------------
 
     paramName = "sensors.qos_history";
-    declare_parameter(paramName, rclcpp::ParameterValue(qos_hist));
+    declare_parameter(paramName, rclcpp::ParameterValue(qos_hist), read_only_descriptor);
 
     if (get_parameter(paramName, paramVal)) {
         qos_hist = paramVal.as_int() == 1 ? RMW_QOS_POLICY_HISTORY_KEEP_LAST
@@ -797,7 +803,7 @@ void ZedCamera::getSensorsParams()
     // ------------------------------------------
 
     paramName = "sensors.qos_depth";
-    declare_parameter(paramName, rclcpp::ParameterValue(qos_depth));
+    declare_parameter(paramName, rclcpp::ParameterValue(qos_depth), read_only_descriptor);
 
     if (get_parameter(paramName, paramVal)) {
         qos_depth = paramVal.as_int();
@@ -813,7 +819,7 @@ void ZedCamera::getSensorsParams()
     // ------------------------------------------
 
     paramName = "sensors.qos_reliability";
-    declare_parameter(paramName, rclcpp::ParameterValue(qos_reliability));
+    declare_parameter(paramName, rclcpp::ParameterValue(qos_reliability), read_only_descriptor);
 
     if (get_parameter(paramName, paramVal)) {
         qos_reliability = paramVal.as_int() == 1
@@ -833,7 +839,7 @@ void ZedCamera::getSensorsParams()
     // ------------------------------------------
 
     paramName = "sensors.qos_durability";
-    declare_parameter(paramName, rclcpp::ParameterValue(qos_durability));
+    declare_parameter(paramName, rclcpp::ParameterValue(qos_durability), read_only_descriptor);
 
     if (get_parameter(paramName, paramVal)) {
         qos_durability = paramVal.as_int() == 1
@@ -860,6 +866,8 @@ void ZedCamera::getMappingParams()
     int qos_depth = 1;
     rmw_qos_reliability_policy_t qos_reliability = RMW_QOS_POLICY_RELIABILITY_RELIABLE;
     rmw_qos_durability_policy_t qos_durability = RMW_QOS_POLICY_DURABILITY_VOLATILE;
+    rcl_interfaces::msg::ParameterDescriptor read_only_descriptor;
+    read_only_descriptor.read_only = true;
 
     RCLCPP_INFO(get_logger(), "*** Spatial Mapping parameters ***");
 
@@ -893,7 +901,7 @@ void ZedCamera::getMappingParams()
 
     paramName
         = "mapping.qos_history";
-    declare_parameter(paramName, rclcpp::ParameterValue(qos_hist));
+    declare_parameter(paramName, rclcpp::ParameterValue(qos_hist), read_only_descriptor);
 
     if (get_parameter(paramName, paramVal)) {
         qos_hist = paramVal.as_int() == 1 ? RMW_QOS_POLICY_HISTORY_KEEP_LAST
@@ -912,7 +920,7 @@ void ZedCamera::getMappingParams()
     // ------------------------------------------
 
     paramName = "mapping.qos_depth";
-    declare_parameter(paramName, rclcpp::ParameterValue(qos_depth));
+    declare_parameter(paramName, rclcpp::ParameterValue(qos_depth), read_only_descriptor);
 
     if (get_parameter(paramName, paramVal)) {
         qos_depth = paramVal.as_int();
@@ -928,7 +936,7 @@ void ZedCamera::getMappingParams()
     // ------------------------------------------
 
     paramName = "mapping.qos_reliability";
-    declare_parameter(paramName, rclcpp::ParameterValue(qos_reliability));
+    declare_parameter(paramName, rclcpp::ParameterValue(qos_reliability), read_only_descriptor);
 
     if (get_parameter(paramName, paramVal)) {
         qos_reliability = paramVal.as_int() == 1
@@ -948,7 +956,7 @@ void ZedCamera::getMappingParams()
     // ------------------------------------------
 
     paramName = "mapping.qos_durability";
-    declare_parameter(paramName, rclcpp::ParameterValue(qos_durability));
+    declare_parameter(paramName, rclcpp::ParameterValue(qos_durability), read_only_descriptor);
 
     if (get_parameter(paramName, paramVal)) {
         qos_durability = paramVal.as_int() == 1
@@ -975,6 +983,8 @@ void ZedCamera::getPosTrackingParams()
     int qos_depth = 1;
     rmw_qos_reliability_policy_t qos_reliability = RMW_QOS_POLICY_RELIABILITY_RELIABLE;
     rmw_qos_durability_policy_t qos_durability = RMW_QOS_POLICY_DURABILITY_VOLATILE;
+    rcl_interfaces::msg::ParameterDescriptor read_only_descriptor;
+    read_only_descriptor.read_only = true;
 
     RCLCPP_INFO(get_logger(), "*** POSITIONAL TRACKING parameters ***");
 
@@ -1014,7 +1024,8 @@ void ZedCamera::getPosTrackingParams()
     getParam("pos_tracking.path_pub_rate",
         mPathPubRate,
         mPathPubRate,
-        " * [DYN] Path publishing rate: ");
+        " * [DYN] Path publishing rate: ",
+        true);
     getParam("pos_tracking.path_max_count", mPathMaxCount, mPathMaxCount);
     if (mPathMaxCount < 2 && mPathMaxCount != -1) {
         mPathMaxCount = 2;
@@ -1022,7 +1033,7 @@ void ZedCamera::getPosTrackingParams()
     RCLCPP_INFO_STREAM(get_logger(), " * Path history lenght: " << mPathMaxCount);
 
     paramName = "pos_tracking.initial_base_pose";
-    declare_parameter(paramName, rclcpp::ParameterValue(mInitialBasePose));
+    declare_parameter(paramName, rclcpp::ParameterValue(mInitialBasePose), read_only_descriptor);
     if (!get_parameter(paramName, mInitialBasePose)) {
         RCLCPP_WARN_STREAM(
             get_logger(),
@@ -1081,7 +1092,7 @@ void ZedCamera::getPosTrackingParams()
     // ------------------------------------------
 
     paramName = "pos_tracking.qos_history";
-    declare_parameter(paramName, rclcpp::ParameterValue(qos_hist));
+    declare_parameter(paramName, rclcpp::ParameterValue(qos_hist), read_only_descriptor);
 
     if (get_parameter(paramName, paramVal)) {
         qos_hist = paramVal.as_int() == 1 ? RMW_QOS_POLICY_HISTORY_KEEP_LAST
@@ -1100,7 +1111,7 @@ void ZedCamera::getPosTrackingParams()
     // ------------------------------------------
 
     paramName = "pos_tracking.qos_depth";
-    declare_parameter(paramName, rclcpp::ParameterValue(qos_depth));
+    declare_parameter(paramName, rclcpp::ParameterValue(qos_depth), read_only_descriptor);
 
     if (get_parameter(paramName, paramVal)) {
         qos_depth = paramVal.as_int();
@@ -1117,7 +1128,7 @@ void ZedCamera::getPosTrackingParams()
     // ------------------------------------------
 
     paramName = "pos_tracking.qos_reliability";
-    declare_parameter(paramName, rclcpp::ParameterValue(qos_reliability));
+    declare_parameter(paramName, rclcpp::ParameterValue(qos_reliability), read_only_descriptor);
 
     if (get_parameter(paramName, paramVal)) {
         qos_reliability = paramVal.as_int() == 1
@@ -1137,7 +1148,7 @@ void ZedCamera::getPosTrackingParams()
     // ------------------------------------------
 
     paramName = "pos_tracking.qos_durability";
-    declare_parameter(paramName, rclcpp::ParameterValue(qos_durability));
+    declare_parameter(paramName, rclcpp::ParameterValue(qos_durability), read_only_descriptor);
 
     if (get_parameter(paramName, paramVal)) {
         qos_durability = paramVal.as_int() == 1
@@ -1164,6 +1175,8 @@ void ZedCamera::getOdParams()
     int qos_depth = 1;
     rmw_qos_reliability_policy_t qos_reliability = RMW_QOS_POLICY_RELIABILITY_RELIABLE;
     rmw_qos_durability_policy_t qos_durability = RMW_QOS_POLICY_DURABILITY_VOLATILE;
+    rcl_interfaces::msg::ParameterDescriptor read_only_descriptor;
+    read_only_descriptor.read_only = true;
 
     RCLCPP_INFO(get_logger(), "*** OBJECT DETECTION parameters ***");
     if (mCamUserModel == sl::MODEL::ZED || mCamUserModel == sl::MODEL::ZED_M) {
@@ -1257,7 +1270,7 @@ void ZedCamera::getOdParams()
     // ------------------------------------------
 
     paramName = "object_detection.qos_history";
-    declare_parameter(paramName, rclcpp::ParameterValue(qos_hist));
+    declare_parameter(paramName, rclcpp::ParameterValue(qos_hist), read_only_descriptor);
 
     if (get_parameter(paramName, paramVal)) {
         qos_hist = paramVal.as_int() == 1 ? RMW_QOS_POLICY_HISTORY_KEEP_LAST
@@ -1276,7 +1289,7 @@ void ZedCamera::getOdParams()
     // ------------------------------------------
 
     paramName = "object_detection.qos_depth";
-    declare_parameter(paramName, rclcpp::ParameterValue(qos_depth));
+    declare_parameter(paramName, rclcpp::ParameterValue(qos_depth), read_only_descriptor);
 
     if (get_parameter(paramName, paramVal)) {
         qos_depth = paramVal.as_int();
@@ -1292,7 +1305,7 @@ void ZedCamera::getOdParams()
     // ------------------------------------------
 
     paramName = "object_detection.qos_reliability";
-    declare_parameter(paramName, rclcpp::ParameterValue(qos_reliability));
+    declare_parameter(paramName, rclcpp::ParameterValue(qos_reliability), read_only_descriptor);
 
     if (get_parameter(paramName, paramVal)) {
         qos_reliability = paramVal.as_int() == 1
@@ -1312,7 +1325,7 @@ void ZedCamera::getOdParams()
     // ------------------------------------------
 
     paramName = "object_detection.qos_durability";
-    declare_parameter(paramName, rclcpp::ParameterValue(qos_durability));
+    declare_parameter(paramName, rclcpp::ParameterValue(qos_durability), read_only_descriptor);
 
     if (get_parameter(paramName, paramVal)) {
         qos_durability = paramVal.as_int() == 1

--- a/zed_components/src/zed_camera/src/zed_camera_component.cpp
+++ b/zed_components/src/zed_camera/src/zed_camera_component.cpp
@@ -1351,496 +1351,502 @@ ZedCamera::callback_paramChange(std::vector<rclcpp::Parameter> parameters)
     rcl_interfaces::msg::SetParametersResult result;
     result.successful = true;
 
-    for (const auto& param : parameters) {
-        if (param.get_name() == "general.pub_frame_rate") {
-            rclcpp::ParameterType correctType = rclcpp::ParameterType::PARAMETER_DOUBLE;
-            if (param.get_type() != correctType) {
-                result.successful = false;
-                result.reason = param.get_name() + " must be a " + rclcpp::to_string(correctType);
-                RCLCPP_WARN_STREAM(get_logger(), result.reason);
-                return result;
-            }
-
-            double val = param.as_double();
-
-            if ((val <= 0.0) || (val > mCamGrabFrameRate)) {
-                result.successful = false;
-                result.reason = param.get_name() + " must be positive and minor or equal to `grab_frame_rate`";
-                RCLCPP_WARN_STREAM(get_logger(), result.reason);
-                return result;
-            }
-
-            mPubFrameRate = val;
-            startVideoDepthTimer(mPubFrameRate);
-
-            RCLCPP_INFO_STREAM(get_logger(),
-                "Parameter '" << param.get_name()
-                              << "' correctly set to " << val);
-        } else if (param.get_name() == "video.brightness") {
-            rclcpp::ParameterType correctType = rclcpp::ParameterType::PARAMETER_INTEGER;
-            if (param.get_type() != correctType) {
-                result.successful = false;
-                result.reason = param.get_name() + " must be a " + rclcpp::to_string(correctType);
-                RCLCPP_WARN_STREAM(get_logger(), result.reason);
-                return result;
-            }
-
-            int val = param.as_int();
-
-            if ((val < 0) || (val > 8)) {
-                result.successful = false;
-                result.reason = param.get_name() + " must be a positive integer in the range [0,8]";
-                RCLCPP_WARN_STREAM(get_logger(), result.reason);
-                return result;
-            }
-
-            mCamBrightness = val;
-
-            RCLCPP_INFO_STREAM(get_logger(),
-                "Parameter '" << param.get_name()
-                              << "' correctly set to " << val);
-        } else if (param.get_name() == "video.contrast") {
-            rclcpp::ParameterType correctType = rclcpp::ParameterType::PARAMETER_INTEGER;
-            if (param.get_type() != correctType) {
-                result.successful = false;
-                result.reason = param.get_name() + " must be a " + rclcpp::to_string(correctType);
-                RCLCPP_WARN_STREAM(get_logger(), result.reason);
-                return result;
-            }
-
-            int val = param.as_int();
-
-            if ((val < 0) || (val > 8)) {
-                result.successful = false;
-                result.reason = param.get_name() + " must be a positive integer in the range [0,8]";
-                RCLCPP_WARN_STREAM(get_logger(), result.reason);
-                return result;
-            }
-
-            mCamContrast = val;
-
-            RCLCPP_INFO_STREAM(get_logger(),
-                "Parameter '" << param.get_name()
-                              << "' correctly set to " << val);
-        } else if (param.get_name() == "video.hue") {
-            rclcpp::ParameterType correctType = rclcpp::ParameterType::PARAMETER_INTEGER;
-            if (param.get_type() != correctType) {
-                result.successful = false;
-                result.reason = param.get_name() + " must be a " + rclcpp::to_string(correctType);
-                RCLCPP_WARN_STREAM(get_logger(), result.reason);
-                return result;
-            }
-
-            int val = param.as_int();
-
-            if ((val < 0) || (val > 11)) {
-                result.successful = false;
-                result.reason = param.get_name() + " must be a positive integer in the range [0,11]";
-                RCLCPP_WARN_STREAM(get_logger(), result.reason);
-                return result;
-            }
-
-            mCamHue = val;
-
-            RCLCPP_INFO_STREAM(get_logger(),
-                "Parameter '" << param.get_name()
-                              << "' correctly set to " << val);
-        } else if (param.get_name() == "video.sharpness") {
-            rclcpp::ParameterType correctType = rclcpp::ParameterType::PARAMETER_INTEGER;
-            if (param.get_type() != correctType) {
-                result.successful = false;
-                result.reason = param.get_name() + " must be a " + rclcpp::to_string(correctType);
-                RCLCPP_WARN_STREAM(get_logger(), result.reason);
-                return result;
-            }
-
-            int val = param.as_int();
-
-            if ((val < 0) || (val > 8)) {
-                result.successful = false;
-                result.reason = param.get_name() + " must be a positive integer in the range [0,8]";
-                RCLCPP_WARN_STREAM(get_logger(), result.reason);
-                return result;
-            }
-
-            mCamSharpness = val;
-
-            RCLCPP_INFO_STREAM(get_logger(),
-                "Parameter '" << param.get_name()
-                              << "' correctly set to " << val);
-        } else if (param.get_name() == "video.gamma") {
-            rclcpp::ParameterType correctType = rclcpp::ParameterType::PARAMETER_INTEGER;
-            if (param.get_type() != correctType) {
-                result.successful = false;
-                result.reason = param.get_name() + " must be a " + rclcpp::to_string(correctType);
-                RCLCPP_WARN_STREAM(get_logger(), result.reason);
-                return result;
-            }
-
-            int val = param.as_int();
-
-            if ((val < 0) || (val > 8)) {
-                result.successful = false;
-                result.reason = param.get_name() + " must be a positive integer in the range [0,8]";
-                RCLCPP_WARN_STREAM(get_logger(), result.reason);
-                return result;
-            }
-
-            mCamGamma = val;
-
-            RCLCPP_INFO_STREAM(get_logger(),
-                "Parameter '" << param.get_name()
-                              << "' correctly set to " << val);
-        } else if (param.get_name() == "video.auto_exposure_gain") {
-            rclcpp::ParameterType correctType = rclcpp::ParameterType::PARAMETER_BOOL;
-            if (param.get_type() != correctType) {
-                result.successful = false;
-                result.reason = param.get_name() + " must be a " + rclcpp::to_string(correctType);
-                RCLCPP_WARN_STREAM(get_logger(), result.reason);
-                return result;
-            }
-
-            bool val = param.as_bool();
-
-            if (val && !mCamAutoExpGain) {
-                mTriggerAutoExpGain = true;
-            }
-
-            mCamAutoExpGain = val;
-
-            RCLCPP_INFO_STREAM(get_logger(),
-                "Parameter '" << param.get_name()
-                              << "' correctly set to " << val);
-        } else if (param.get_name() == "video.exposure") {
-            rclcpp::ParameterType correctType = rclcpp::ParameterType::PARAMETER_INTEGER;
-            if (param.get_type() != correctType) {
-                result.successful = false;
-                result.reason = param.get_name() + " must be a " + rclcpp::to_string(correctType);
-                RCLCPP_WARN_STREAM(get_logger(), result.reason);
-                return result;
-            }
-
-            int val = param.as_int();
-
-            if ((val < 0) || (val > 100)) {
-                result.successful = false;
-                result.reason = param.get_name() + " must be a positive integer in the range [0,100]";
-                RCLCPP_WARN_STREAM(get_logger(), result.reason);
-                return result;
-            }
-
-            mCamExposure = val;
-            mCamAutoExpGain = false;
-
-            RCLCPP_INFO_STREAM(get_logger(),
-                "Parameter '" << param.get_name()
-                              << "' correctly set to " << val);
-        } else if (param.get_name() == "video.gain") {
-            rclcpp::ParameterType correctType = rclcpp::ParameterType::PARAMETER_INTEGER;
-            if (param.get_type() != correctType) {
-                result.successful = false;
-                result.reason = param.get_name() + " must be a " + rclcpp::to_string(correctType);
-                RCLCPP_WARN_STREAM(get_logger(), result.reason);
-                return result;
-            }
-
-            int val = param.as_int();
-
-            if ((val < 0) || (val > 100)) {
-                result.successful = false;
-                result.reason = param.get_name() + " must be a positive integer in the range [0,100]";
-                RCLCPP_WARN_STREAM(get_logger(), result.reason);
-                return result;
-            }
-
-            mCamGain = val;
-            mCamAutoExpGain = false;
-
-            RCLCPP_INFO_STREAM(get_logger(),
-                "Parameter '" << param.get_name()
-                              << "' correctly set to " << val);
-        } else if (param.get_name() == "video.auto_whitebalance") {
-            rclcpp::ParameterType correctType = rclcpp::ParameterType::PARAMETER_BOOL;
-            if (param.get_type() != correctType) {
-                result.successful = false;
-                result.reason = param.get_name() + " must be a " + rclcpp::to_string(correctType);
-                RCLCPP_WARN_STREAM(get_logger(), result.reason);
-                return result;
-            }
-
-            bool val = param.as_bool();
-
-            if (val && !mCamAutoWB) {
-                mTriggerAutoWB = true;
-            }
-
-            mCamAutoWB = val;
-
-            RCLCPP_INFO_STREAM(get_logger(),
-                "Parameter '" << param.get_name()
-                              << "' correctly set to " << val);
-        } else if (param.get_name() == "video.whitebalance_temperature") {
-            rclcpp::ParameterType correctType = rclcpp::ParameterType::PARAMETER_INTEGER;
-            if (param.get_type() != correctType) {
-                result.successful = false;
-                result.reason = param.get_name() + " must be a " + rclcpp::to_string(correctType);
-                RCLCPP_WARN_STREAM(get_logger(), result.reason);
-                return result;
-            }
-
-            int val = param.as_int();
-
-            if ((val < 28) || (val > 65)) {
-                result.successful = false;
-                result.reason = param.get_name() + " must be a positive integer in the range [28,65]";
-                RCLCPP_WARN_STREAM(get_logger(), result.reason);
-                return result;
-            }
-
-            mCamWBTemp = val * 100;
-            mCamAutoWB = false;
-
-            RCLCPP_INFO_STREAM(get_logger(),
-                "Parameter '" << param.get_name()
-                              << "' correctly set to " << val);
-        } else if (param.get_name() == "depth.point_cloud_freq") {
-            rclcpp::ParameterType correctType = rclcpp::ParameterType::PARAMETER_DOUBLE;
-            if (param.get_type() != correctType) {
-                result.successful = false;
-                result.reason = param.get_name() + " must be a " + rclcpp::to_string(correctType);
-                RCLCPP_WARN_STREAM(get_logger(), result.reason);
-                return result;
-            }
-
-            double val = param.as_double();
-
-            if ((val <= 0.0) || (val > mCamGrabFrameRate)) {
-                result.successful = false;
-                result.reason = param.get_name() + " must be positive and minor of `grab_frame_rate`";
-                RCLCPP_WARN_STREAM(get_logger(), result.reason);
-                return result;
-            }
-
-            mPubFrameRate = val;
-            startVideoDepthTimer(mPubFrameRate);
-
-            RCLCPP_INFO_STREAM(get_logger(),
-                "Parameter '" << param.get_name()
-                              << "' correctly set to " << val);
-        } else if (param.get_name() == "depth.depth_confidence") {
-            rclcpp::ParameterType correctType = rclcpp::ParameterType::PARAMETER_INTEGER;
-            if (param.get_type() != correctType) {
-                result.successful = false;
-                result.reason = param.get_name() + " must be a " + rclcpp::to_string(correctType);
-                RCLCPP_WARN_STREAM(get_logger(), result.reason);
-                return result;
-            }
-
-            int val = param.as_int();
-
-            if ((val < 0) || (val > 100)) {
-                result.successful = false;
-                result.reason = param.get_name() + " must be a positive integer in the range [0,100]";
-                RCLCPP_WARN_STREAM(get_logger(), result.reason);
-                return result;
-            }
-
-            mDepthConf = val;
-
-            RCLCPP_INFO_STREAM(get_logger(),
-                "Parameter '" << param.get_name()
-                              << "' correctly set to " << val);
-        } else if (param.get_name() == "depth.depth_texture_conf") {
-            rclcpp::ParameterType correctType = rclcpp::ParameterType::PARAMETER_INTEGER;
-            if (param.get_type() != correctType) {
-                result.successful = false;
-                result.reason = param.get_name() + " must be a " + rclcpp::to_string(correctType);
-                RCLCPP_WARN_STREAM(get_logger(), result.reason);
-                return result;
-            }
-
-            int val = param.as_int();
-
-            if ((val < 0) || (val > 100)) {
-                result.successful = false;
-                result.reason = param.get_name() + " must be a positive integer in the range [0,100]";
-                RCLCPP_WARN_STREAM(get_logger(), result.reason);
-                return result;
-            }
-
-            mDepthTextConf = val;
-
-            RCLCPP_INFO_STREAM(get_logger(),
-                "Parameter '" << param.get_name()
-                              << "' correctly set to " << val);
-        } else if (param.get_name() == "depth.remove_saturated_areas") {
-            rclcpp::ParameterType correctType = rclcpp::ParameterType::PARAMETER_BOOL;
-            if (param.get_type() != correctType) {
-                result.successful = false;
-                result.reason = param.get_name() + " must be a " + rclcpp::to_string(correctType);
-                RCLCPP_WARN_STREAM(get_logger(), result.reason);
-                return result;
-            }
-
-            mRemoveSatAreas = param.as_bool();
-
-            RCLCPP_INFO_STREAM(get_logger(),
-                "Parameter '"
-                    << param.get_name() << "' correctly set to "
-                    << (mRemoveSatAreas ? "TRUE" : "FALSE"));
-        } else if (param.get_name() == "mapping.fused_pointcloud_freq") {
-            rclcpp::ParameterType correctType = rclcpp::ParameterType::PARAMETER_DOUBLE;
-            if (param.get_type() != correctType) {
-                result.successful = false;
-                result.reason = param.get_name() + " must be a " + rclcpp::to_string(correctType);
-                RCLCPP_WARN_STREAM(get_logger(), result.reason);
-                return result;
-            }
-
-            double val = param.as_double();
-
-            if ((val <= 0.0) || (val > mPcPubRate)) {
-                result.successful = false;
-                result.reason = param.get_name() + " must be positive and minor of `point_cloud_freq`";
-                RCLCPP_WARN_STREAM(get_logger(), result.reason);
-                return result;
-            }
-
-            mFusedPcPubRate = val;
-            startFusedPcTimer(mFusedPcPubRate);
-
-            RCLCPP_INFO_STREAM(get_logger(),
-                "Parameter '" << param.get_name()
-                              << "' correctly set to " << val);
-        } else if (param.get_name() == "object_detection.confidence_threshold") {
-            rclcpp::ParameterType correctType = rclcpp::ParameterType::PARAMETER_DOUBLE;
-            if (param.get_type() != correctType) {
-                result.successful = false;
-                result.reason = param.get_name() + " must be a " + rclcpp::to_string(correctType);
-                RCLCPP_WARN_STREAM(get_logger(), result.reason);
-                return result;
-            }
-
-            double val = param.as_double();
-
-            if ((val < 0.0) || (val > 100.0)) {
-                result.successful = false;
-                result.reason = param.get_name() + " must be positive double value in the range [0.0,100.0]";
-                RCLCPP_WARN_STREAM(get_logger(), result.reason);
-                return result;
-            }
-
-            mObjDetConfidence = val;
-
-            RCLCPP_INFO_STREAM(get_logger(),
-                "Parameter '" << param.get_name()
-                              << "' correctly set to " << val);
-        } else if (param.get_name() == "object_detection.mc_people") {
-            rclcpp::ParameterType correctType = rclcpp::ParameterType::PARAMETER_BOOL;
-            if (param.get_type() != correctType) {
-                result.successful = false;
-                result.reason = param.get_name() + " must be a " + rclcpp::to_string(correctType);
-                RCLCPP_WARN_STREAM(get_logger(), result.reason);
-                return result;
-            }
-
-            mObjDetPeopleEnable = param.as_bool();
-
-            RCLCPP_INFO_STREAM(get_logger(),
-                "Parameter '"
-                    << param.get_name() << "' correctly set to "
-                    << (mObjDetPeopleEnable ? "TRUE" : "FALSE"));
-        } else if (param.get_name() == "object_detection.mc_vehicle") {
-            rclcpp::ParameterType correctType = rclcpp::ParameterType::PARAMETER_BOOL;
-            if (param.get_type() != correctType) {
-                result.successful = false;
-                result.reason = param.get_name() + " must be a " + rclcpp::to_string(correctType);
-                RCLCPP_WARN_STREAM(get_logger(), result.reason);
-                return result;
-            }
-
-            mObjDetVehiclesEnable = param.as_bool();
-
-            RCLCPP_INFO_STREAM(get_logger(),
-                "Parameter '"
-                    << param.get_name() << "' correctly set to "
-                    << (mObjDetVehiclesEnable ? "TRUE" : "FALSE"));
-        } else if (param.get_name() == "object_detection.mc_bag") {
-            rclcpp::ParameterType correctType = rclcpp::ParameterType::PARAMETER_BOOL;
-            if (param.get_type() != correctType) {
-                result.successful = false;
-                result.reason = param.get_name() + " must be a " + rclcpp::to_string(correctType);
-                RCLCPP_WARN_STREAM(get_logger(), result.reason);
-                return result;
-            }
-
-            mObjDetBagsEnable = param.as_bool();
-
-            RCLCPP_INFO_STREAM(get_logger(),
-                "Parameter '"
-                    << param.get_name() << "' correctly set to "
-                    << (mObjDetBagsEnable ? "TRUE" : "FALSE"));
-        } else if (param.get_name() == "object_detection.mc_animal") {
-            rclcpp::ParameterType correctType = rclcpp::ParameterType::PARAMETER_BOOL;
-            if (param.get_type() != correctType) {
-                result.successful = false;
-                result.reason = param.get_name() + " must be a " + rclcpp::to_string(correctType);
-                RCLCPP_WARN_STREAM(get_logger(), result.reason);
-                return result;
-            }
-
-            mObjDetAnimalsEnable = param.as_bool();
-
-            RCLCPP_INFO_STREAM(get_logger(),
-                "Parameter '"
-                    << param.get_name() << "' correctly set to "
-                    << (mObjDetAnimalsEnable ? "TRUE" : "FALSE"));
-        } else if (param.get_name() == "object_detection.mc_electronics") {
-            rclcpp::ParameterType correctType = rclcpp::ParameterType::PARAMETER_BOOL;
-            if (param.get_type() != correctType) {
-                result.successful = false;
-                result.reason = param.get_name() + " must be a " + rclcpp::to_string(correctType);
-                RCLCPP_WARN_STREAM(get_logger(), result.reason);
-                return result;
-            }
-
-            mObjDetElectronicsEnable = param.as_bool();
-
-            RCLCPP_INFO_STREAM(get_logger(),
-                "Parameter '"
-                    << param.get_name() << "' correctly set to "
-                    << (mObjDetElectronicsEnable ? "TRUE" : "FALSE"));
-        } else if (param.get_name() == "object_detection.mc_fruit_vegetable") {
-            rclcpp::ParameterType correctType = rclcpp::ParameterType::PARAMETER_BOOL;
-            if (param.get_type() != correctType) {
-                result.successful = false;
-                result.reason = param.get_name() + " must be a " + rclcpp::to_string(correctType);
-                RCLCPP_WARN_STREAM(get_logger(), result.reason);
-                return result;
-            }
-
-            mObjDetFruitsEnable = param.as_bool();
-
-            RCLCPP_INFO_STREAM(get_logger(),
-                "Parameter '"
-                    << param.get_name() << "' correctly set to "
-                    << (mObjDetFruitsEnable ? "TRUE" : "FALSE"));
-        } else if (param.get_name() == "object_detection.mc_sport") {
-            rclcpp::ParameterType correctType = rclcpp::ParameterType::PARAMETER_BOOL;
-            if (param.get_type() != correctType) {
-                result.successful = false;
-                result.reason = param.get_name() + " must be a " + rclcpp::to_string(correctType);
-                RCLCPP_WARN_STREAM(get_logger(), result.reason);
-                return result;
-            }
-
-            mObjDetSportEnable = param.as_bool();
-
-            RCLCPP_INFO_STREAM(get_logger(),
-                "Parameter '"
-                    << param.get_name() << "' correctly set to "
-                    << (mObjDetSportEnable ? "TRUE" : "FALSE"));
+    if (parameters.size() > 1) {
+        result.successful = false;
+        result.reason = "The node does not support setting multiple parameters atomically";
+        return result;
+    }
+
+    auto& param = parameters[0];
+
+    if (param.get_name() == "general.pub_frame_rate") {
+        rclcpp::ParameterType correctType = rclcpp::ParameterType::PARAMETER_DOUBLE;
+        if (param.get_type() != correctType) {
+            result.successful = false;
+            result.reason = param.get_name() + " must be a " + rclcpp::to_string(correctType);
+            RCLCPP_WARN_STREAM(get_logger(), result.reason);
+            return result;
         }
+
+        double val = param.as_double();
+
+        if ((val <= 0.0) || (val > mCamGrabFrameRate)) {
+            result.successful = false;
+            result.reason = param.get_name() + " must be positive and minor or equal to `grab_frame_rate`";
+            RCLCPP_WARN_STREAM(get_logger(), result.reason);
+            return result;
+        }
+
+        mPubFrameRate = val;
+        startVideoDepthTimer(mPubFrameRate);
+
+        RCLCPP_INFO_STREAM(get_logger(),
+            "Parameter '" << param.get_name()
+                            << "' correctly set to " << val);
+    } else if (param.get_name() == "video.brightness") {
+        rclcpp::ParameterType correctType = rclcpp::ParameterType::PARAMETER_INTEGER;
+        if (param.get_type() != correctType) {
+            result.successful = false;
+            result.reason = param.get_name() + " must be a " + rclcpp::to_string(correctType);
+            RCLCPP_WARN_STREAM(get_logger(), result.reason);
+            return result;
+        }
+
+        int val = param.as_int();
+
+        if ((val < 0) || (val > 8)) {
+            result.successful = false;
+            result.reason = param.get_name() + " must be a positive integer in the range [0,8]";
+            RCLCPP_WARN_STREAM(get_logger(), result.reason);
+            return result;
+        }
+
+        mCamBrightness = val;
+
+        RCLCPP_INFO_STREAM(get_logger(),
+            "Parameter '" << param.get_name()
+                            << "' correctly set to " << val);
+    } else if (param.get_name() == "video.contrast") {
+        rclcpp::ParameterType correctType = rclcpp::ParameterType::PARAMETER_INTEGER;
+        if (param.get_type() != correctType) {
+            result.successful = false;
+            result.reason = param.get_name() + " must be a " + rclcpp::to_string(correctType);
+            RCLCPP_WARN_STREAM(get_logger(), result.reason);
+            return result;
+        }
+
+        int val = param.as_int();
+
+        if ((val < 0) || (val > 8)) {
+            result.successful = false;
+            result.reason = param.get_name() + " must be a positive integer in the range [0,8]";
+            RCLCPP_WARN_STREAM(get_logger(), result.reason);
+            return result;
+        }
+
+        mCamContrast = val;
+
+        RCLCPP_INFO_STREAM(get_logger(),
+            "Parameter '" << param.get_name()
+                            << "' correctly set to " << val);
+    } else if (param.get_name() == "video.hue") {
+        rclcpp::ParameterType correctType = rclcpp::ParameterType::PARAMETER_INTEGER;
+        if (param.get_type() != correctType) {
+            result.successful = false;
+            result.reason = param.get_name() + " must be a " + rclcpp::to_string(correctType);
+            RCLCPP_WARN_STREAM(get_logger(), result.reason);
+            return result;
+        }
+
+        int val = param.as_int();
+
+        if ((val < 0) || (val > 11)) {
+            result.successful = false;
+            result.reason = param.get_name() + " must be a positive integer in the range [0,11]";
+            RCLCPP_WARN_STREAM(get_logger(), result.reason);
+            return result;
+        }
+
+        mCamHue = val;
+
+        RCLCPP_INFO_STREAM(get_logger(),
+            "Parameter '" << param.get_name()
+                            << "' correctly set to " << val);
+    } else if (param.get_name() == "video.sharpness") {
+        rclcpp::ParameterType correctType = rclcpp::ParameterType::PARAMETER_INTEGER;
+        if (param.get_type() != correctType) {
+            result.successful = false;
+            result.reason = param.get_name() + " must be a " + rclcpp::to_string(correctType);
+            RCLCPP_WARN_STREAM(get_logger(), result.reason);
+            return result;
+        }
+
+        int val = param.as_int();
+
+        if ((val < 0) || (val > 8)) {
+            result.successful = false;
+            result.reason = param.get_name() + " must be a positive integer in the range [0,8]";
+            RCLCPP_WARN_STREAM(get_logger(), result.reason);
+            return result;
+        }
+
+        mCamSharpness = val;
+
+        RCLCPP_INFO_STREAM(get_logger(),
+            "Parameter '" << param.get_name()
+                            << "' correctly set to " << val);
+    } else if (param.get_name() == "video.gamma") {
+        rclcpp::ParameterType correctType = rclcpp::ParameterType::PARAMETER_INTEGER;
+        if (param.get_type() != correctType) {
+            result.successful = false;
+            result.reason = param.get_name() + " must be a " + rclcpp::to_string(correctType);
+            RCLCPP_WARN_STREAM(get_logger(), result.reason);
+            return result;
+        }
+
+        int val = param.as_int();
+
+        if ((val < 0) || (val > 8)) {
+            result.successful = false;
+            result.reason = param.get_name() + " must be a positive integer in the range [0,8]";
+            RCLCPP_WARN_STREAM(get_logger(), result.reason);
+            return result;
+        }
+
+        mCamGamma = val;
+
+        RCLCPP_INFO_STREAM(get_logger(),
+            "Parameter '" << param.get_name()
+                            << "' correctly set to " << val);
+    } else if (param.get_name() == "video.auto_exposure_gain") {
+        rclcpp::ParameterType correctType = rclcpp::ParameterType::PARAMETER_BOOL;
+        if (param.get_type() != correctType) {
+            result.successful = false;
+            result.reason = param.get_name() + " must be a " + rclcpp::to_string(correctType);
+            RCLCPP_WARN_STREAM(get_logger(), result.reason);
+            return result;
+        }
+
+        bool val = param.as_bool();
+
+        if (val && !mCamAutoExpGain) {
+            mTriggerAutoExpGain = true;
+        }
+
+        mCamAutoExpGain = val;
+
+        RCLCPP_INFO_STREAM(get_logger(),
+            "Parameter '" << param.get_name()
+                            << "' correctly set to " << val);
+    } else if (param.get_name() == "video.exposure") {
+        rclcpp::ParameterType correctType = rclcpp::ParameterType::PARAMETER_INTEGER;
+        if (param.get_type() != correctType) {
+            result.successful = false;
+            result.reason = param.get_name() + " must be a " + rclcpp::to_string(correctType);
+            RCLCPP_WARN_STREAM(get_logger(), result.reason);
+            return result;
+        }
+
+        int val = param.as_int();
+
+        if ((val < 0) || (val > 100)) {
+            result.successful = false;
+            result.reason = param.get_name() + " must be a positive integer in the range [0,100]";
+            RCLCPP_WARN_STREAM(get_logger(), result.reason);
+            return result;
+        }
+
+        mCamExposure = val;
+        mCamAutoExpGain = false;
+
+        RCLCPP_INFO_STREAM(get_logger(),
+            "Parameter '" << param.get_name()
+                            << "' correctly set to " << val);
+    } else if (param.get_name() == "video.gain") {
+        rclcpp::ParameterType correctType = rclcpp::ParameterType::PARAMETER_INTEGER;
+        if (param.get_type() != correctType) {
+            result.successful = false;
+            result.reason = param.get_name() + " must be a " + rclcpp::to_string(correctType);
+            RCLCPP_WARN_STREAM(get_logger(), result.reason);
+            return result;
+        }
+
+        int val = param.as_int();
+
+        if ((val < 0) || (val > 100)) {
+            result.successful = false;
+            result.reason = param.get_name() + " must be a positive integer in the range [0,100]";
+            RCLCPP_WARN_STREAM(get_logger(), result.reason);
+            return result;
+        }
+
+        mCamGain = val;
+        mCamAutoExpGain = false;
+
+        RCLCPP_INFO_STREAM(get_logger(),
+            "Parameter '" << param.get_name()
+                            << "' correctly set to " << val);
+    } else if (param.get_name() == "video.auto_whitebalance") {
+        rclcpp::ParameterType correctType = rclcpp::ParameterType::PARAMETER_BOOL;
+        if (param.get_type() != correctType) {
+            result.successful = false;
+            result.reason = param.get_name() + " must be a " + rclcpp::to_string(correctType);
+            RCLCPP_WARN_STREAM(get_logger(), result.reason);
+            return result;
+        }
+
+        bool val = param.as_bool();
+
+        if (val && !mCamAutoWB) {
+            mTriggerAutoWB = true;
+        }
+
+        mCamAutoWB = val;
+
+        RCLCPP_INFO_STREAM(get_logger(),
+            "Parameter '" << param.get_name()
+                            << "' correctly set to " << val);
+    } else if (param.get_name() == "video.whitebalance_temperature") {
+        rclcpp::ParameterType correctType = rclcpp::ParameterType::PARAMETER_INTEGER;
+        if (param.get_type() != correctType) {
+            result.successful = false;
+            result.reason = param.get_name() + " must be a " + rclcpp::to_string(correctType);
+            RCLCPP_WARN_STREAM(get_logger(), result.reason);
+            return result;
+        }
+
+        int val = param.as_int();
+
+        if ((val < 28) || (val > 65)) {
+            result.successful = false;
+            result.reason = param.get_name() + " must be a positive integer in the range [28,65]";
+            RCLCPP_WARN_STREAM(get_logger(), result.reason);
+            return result;
+        }
+
+        mCamWBTemp = val * 100;
+        mCamAutoWB = false;
+
+        RCLCPP_INFO_STREAM(get_logger(),
+            "Parameter '" << param.get_name()
+                            << "' correctly set to " << val);
+    } else if (param.get_name() == "depth.point_cloud_freq") {
+        rclcpp::ParameterType correctType = rclcpp::ParameterType::PARAMETER_DOUBLE;
+        if (param.get_type() != correctType) {
+            result.successful = false;
+            result.reason = param.get_name() + " must be a " + rclcpp::to_string(correctType);
+            RCLCPP_WARN_STREAM(get_logger(), result.reason);
+            return result;
+        }
+
+        double val = param.as_double();
+
+        if ((val <= 0.0) || (val > mCamGrabFrameRate)) {
+            result.successful = false;
+            result.reason = param.get_name() + " must be positive and minor of `grab_frame_rate`";
+            RCLCPP_WARN_STREAM(get_logger(), result.reason);
+            return result;
+        }
+
+        mPubFrameRate = val;
+        startVideoDepthTimer(mPubFrameRate);
+
+        RCLCPP_INFO_STREAM(get_logger(),
+            "Parameter '" << param.get_name()
+                            << "' correctly set to " << val);
+    } else if (param.get_name() == "depth.depth_confidence") {
+        rclcpp::ParameterType correctType = rclcpp::ParameterType::PARAMETER_INTEGER;
+        if (param.get_type() != correctType) {
+            result.successful = false;
+            result.reason = param.get_name() + " must be a " + rclcpp::to_string(correctType);
+            RCLCPP_WARN_STREAM(get_logger(), result.reason);
+            return result;
+        }
+
+        int val = param.as_int();
+
+        if ((val < 0) || (val > 100)) {
+            result.successful = false;
+            result.reason = param.get_name() + " must be a positive integer in the range [0,100]";
+            RCLCPP_WARN_STREAM(get_logger(), result.reason);
+            return result;
+        }
+
+        mDepthConf = val;
+
+        RCLCPP_INFO_STREAM(get_logger(),
+            "Parameter '" << param.get_name()
+                            << "' correctly set to " << val);
+    } else if (param.get_name() == "depth.depth_texture_conf") {
+        rclcpp::ParameterType correctType = rclcpp::ParameterType::PARAMETER_INTEGER;
+        if (param.get_type() != correctType) {
+            result.successful = false;
+            result.reason = param.get_name() + " must be a " + rclcpp::to_string(correctType);
+            RCLCPP_WARN_STREAM(get_logger(), result.reason);
+            return result;
+        }
+
+        int val = param.as_int();
+
+        if ((val < 0) || (val > 100)) {
+            result.successful = false;
+            result.reason = param.get_name() + " must be a positive integer in the range [0,100]";
+            RCLCPP_WARN_STREAM(get_logger(), result.reason);
+            return result;
+        }
+
+        mDepthTextConf = val;
+
+        RCLCPP_INFO_STREAM(get_logger(),
+            "Parameter '" << param.get_name()
+                            << "' correctly set to " << val);
+    } else if (param.get_name() == "depth.remove_saturated_areas") {
+        rclcpp::ParameterType correctType = rclcpp::ParameterType::PARAMETER_BOOL;
+        if (param.get_type() != correctType) {
+            result.successful = false;
+            result.reason = param.get_name() + " must be a " + rclcpp::to_string(correctType);
+            RCLCPP_WARN_STREAM(get_logger(), result.reason);
+            return result;
+        }
+
+        mRemoveSatAreas = param.as_bool();
+
+        RCLCPP_INFO_STREAM(get_logger(),
+            "Parameter '"
+                << param.get_name() << "' correctly set to "
+                << (mRemoveSatAreas ? "TRUE" : "FALSE"));
+    } else if (param.get_name() == "mapping.fused_pointcloud_freq") {
+        rclcpp::ParameterType correctType = rclcpp::ParameterType::PARAMETER_DOUBLE;
+        if (param.get_type() != correctType) {
+            result.successful = false;
+            result.reason = param.get_name() + " must be a " + rclcpp::to_string(correctType);
+            RCLCPP_WARN_STREAM(get_logger(), result.reason);
+            return result;
+        }
+
+        double val = param.as_double();
+
+        if ((val <= 0.0) || (val > mPcPubRate)) {
+            result.successful = false;
+            result.reason = param.get_name() + " must be positive and minor of `point_cloud_freq`";
+            RCLCPP_WARN_STREAM(get_logger(), result.reason);
+            return result;
+        }
+
+        mFusedPcPubRate = val;
+        startFusedPcTimer(mFusedPcPubRate);
+
+        RCLCPP_INFO_STREAM(get_logger(),
+            "Parameter '" << param.get_name()
+                            << "' correctly set to " << val);
+    } else if (param.get_name() == "object_detection.confidence_threshold") {
+        rclcpp::ParameterType correctType = rclcpp::ParameterType::PARAMETER_DOUBLE;
+        if (param.get_type() != correctType) {
+            result.successful = false;
+            result.reason = param.get_name() + " must be a " + rclcpp::to_string(correctType);
+            RCLCPP_WARN_STREAM(get_logger(), result.reason);
+            return result;
+        }
+
+        double val = param.as_double();
+
+        if ((val < 0.0) || (val > 100.0)) {
+            result.successful = false;
+            result.reason = param.get_name() + " must be positive double value in the range [0.0,100.0]";
+            RCLCPP_WARN_STREAM(get_logger(), result.reason);
+            return result;
+        }
+
+        mObjDetConfidence = val;
+
+        RCLCPP_INFO_STREAM(get_logger(),
+            "Parameter '" << param.get_name()
+                            << "' correctly set to " << val);
+    } else if (param.get_name() == "object_detection.mc_people") {
+        rclcpp::ParameterType correctType = rclcpp::ParameterType::PARAMETER_BOOL;
+        if (param.get_type() != correctType) {
+            result.successful = false;
+            result.reason = param.get_name() + " must be a " + rclcpp::to_string(correctType);
+            RCLCPP_WARN_STREAM(get_logger(), result.reason);
+            return result;
+        }
+
+        mObjDetPeopleEnable = param.as_bool();
+
+        RCLCPP_INFO_STREAM(get_logger(),
+            "Parameter '"
+                << param.get_name() << "' correctly set to "
+                << (mObjDetPeopleEnable ? "TRUE" : "FALSE"));
+    } else if (param.get_name() == "object_detection.mc_vehicle") {
+        rclcpp::ParameterType correctType = rclcpp::ParameterType::PARAMETER_BOOL;
+        if (param.get_type() != correctType) {
+            result.successful = false;
+            result.reason = param.get_name() + " must be a " + rclcpp::to_string(correctType);
+            RCLCPP_WARN_STREAM(get_logger(), result.reason);
+            return result;
+        }
+
+        mObjDetVehiclesEnable = param.as_bool();
+
+        RCLCPP_INFO_STREAM(get_logger(),
+            "Parameter '"
+                << param.get_name() << "' correctly set to "
+                << (mObjDetVehiclesEnable ? "TRUE" : "FALSE"));
+    } else if (param.get_name() == "object_detection.mc_bag") {
+        rclcpp::ParameterType correctType = rclcpp::ParameterType::PARAMETER_BOOL;
+        if (param.get_type() != correctType) {
+            result.successful = false;
+            result.reason = param.get_name() + " must be a " + rclcpp::to_string(correctType);
+            RCLCPP_WARN_STREAM(get_logger(), result.reason);
+            return result;
+        }
+
+        mObjDetBagsEnable = param.as_bool();
+
+        RCLCPP_INFO_STREAM(get_logger(),
+            "Parameter '"
+                << param.get_name() << "' correctly set to "
+                << (mObjDetBagsEnable ? "TRUE" : "FALSE"));
+    } else if (param.get_name() == "object_detection.mc_animal") {
+        rclcpp::ParameterType correctType = rclcpp::ParameterType::PARAMETER_BOOL;
+        if (param.get_type() != correctType) {
+            result.successful = false;
+            result.reason = param.get_name() + " must be a " + rclcpp::to_string(correctType);
+            RCLCPP_WARN_STREAM(get_logger(), result.reason);
+            return result;
+        }
+
+        mObjDetAnimalsEnable = param.as_bool();
+
+        RCLCPP_INFO_STREAM(get_logger(),
+            "Parameter '"
+                << param.get_name() << "' correctly set to "
+                << (mObjDetAnimalsEnable ? "TRUE" : "FALSE"));
+    } else if (param.get_name() == "object_detection.mc_electronics") {
+        rclcpp::ParameterType correctType = rclcpp::ParameterType::PARAMETER_BOOL;
+        if (param.get_type() != correctType) {
+            result.successful = false;
+            result.reason = param.get_name() + " must be a " + rclcpp::to_string(correctType);
+            RCLCPP_WARN_STREAM(get_logger(), result.reason);
+            return result;
+        }
+
+        mObjDetElectronicsEnable = param.as_bool();
+
+        RCLCPP_INFO_STREAM(get_logger(),
+            "Parameter '"
+                << param.get_name() << "' correctly set to "
+                << (mObjDetElectronicsEnable ? "TRUE" : "FALSE"));
+    } else if (param.get_name() == "object_detection.mc_fruit_vegetable") {
+        rclcpp::ParameterType correctType = rclcpp::ParameterType::PARAMETER_BOOL;
+        if (param.get_type() != correctType) {
+            result.successful = false;
+            result.reason = param.get_name() + " must be a " + rclcpp::to_string(correctType);
+            RCLCPP_WARN_STREAM(get_logger(), result.reason);
+            return result;
+        }
+
+        mObjDetFruitsEnable = param.as_bool();
+
+        RCLCPP_INFO_STREAM(get_logger(),
+            "Parameter '"
+                << param.get_name() << "' correctly set to "
+                << (mObjDetFruitsEnable ? "TRUE" : "FALSE"));
+    } else if (param.get_name() == "object_detection.mc_sport") {
+        rclcpp::ParameterType correctType = rclcpp::ParameterType::PARAMETER_BOOL;
+        if (param.get_type() != correctType) {
+            result.successful = false;
+            result.reason = param.get_name() + " must be a " + rclcpp::to_string(correctType);
+            RCLCPP_WARN_STREAM(get_logger(), result.reason);
+            return result;
+        }
+
+        mObjDetSportEnable = param.as_bool();
+
+        RCLCPP_INFO_STREAM(get_logger(),
+            "Parameter '"
+                << param.get_name() << "' correctly set to "
+                << (mObjDetSportEnable ? "TRUE" : "FALSE"));
     }
 
     return result;

--- a/zed_components/src/zed_camera/src/zed_camera_component.cpp
+++ b/zed_components/src/zed_camera/src/zed_camera_component.cpp
@@ -1349,7 +1349,7 @@ ZedCamera::callback_paramChange(std::vector<rclcpp::Parameter> parameters)
     //RCLCPP_INFO(get_logger(), "Parameter change callback");
 
     rcl_interfaces::msg::SetParametersResult result;
-    result.successful = false;
+    result.successful = true;
 
     for (const auto& param : parameters) {
         if (param.get_name() == "general.pub_frame_rate") {
@@ -1376,9 +1376,6 @@ ZedCamera::callback_paramChange(std::vector<rclcpp::Parameter> parameters)
             RCLCPP_INFO_STREAM(get_logger(),
                 "Parameter '" << param.get_name()
                               << "' correctly set to " << val);
-            result.successful = true;
-            result.reason = param.get_name() + " correctly set.";
-            return result;
         } else if (param.get_name() == "video.brightness") {
             rclcpp::ParameterType correctType = rclcpp::ParameterType::PARAMETER_INTEGER;
             if (param.get_type() != correctType) {
@@ -1402,9 +1399,6 @@ ZedCamera::callback_paramChange(std::vector<rclcpp::Parameter> parameters)
             RCLCPP_INFO_STREAM(get_logger(),
                 "Parameter '" << param.get_name()
                               << "' correctly set to " << val);
-            result.successful = true;
-            result.reason = param.get_name() + " correctly set.";
-            return result;
         } else if (param.get_name() == "video.contrast") {
             rclcpp::ParameterType correctType = rclcpp::ParameterType::PARAMETER_INTEGER;
             if (param.get_type() != correctType) {
@@ -1428,9 +1422,6 @@ ZedCamera::callback_paramChange(std::vector<rclcpp::Parameter> parameters)
             RCLCPP_INFO_STREAM(get_logger(),
                 "Parameter '" << param.get_name()
                               << "' correctly set to " << val);
-            result.successful = true;
-            result.reason = param.get_name() + " correctly set.";
-            return result;
         } else if (param.get_name() == "video.hue") {
             rclcpp::ParameterType correctType = rclcpp::ParameterType::PARAMETER_INTEGER;
             if (param.get_type() != correctType) {
@@ -1454,9 +1445,6 @@ ZedCamera::callback_paramChange(std::vector<rclcpp::Parameter> parameters)
             RCLCPP_INFO_STREAM(get_logger(),
                 "Parameter '" << param.get_name()
                               << "' correctly set to " << val);
-            result.successful = true;
-            result.reason = param.get_name() + " correctly set.";
-            return result;
         } else if (param.get_name() == "video.sharpness") {
             rclcpp::ParameterType correctType = rclcpp::ParameterType::PARAMETER_INTEGER;
             if (param.get_type() != correctType) {
@@ -1480,9 +1468,6 @@ ZedCamera::callback_paramChange(std::vector<rclcpp::Parameter> parameters)
             RCLCPP_INFO_STREAM(get_logger(),
                 "Parameter '" << param.get_name()
                               << "' correctly set to " << val);
-            result.successful = true;
-            result.reason = param.get_name() + " correctly set.";
-            return result;
         } else if (param.get_name() == "video.gamma") {
             rclcpp::ParameterType correctType = rclcpp::ParameterType::PARAMETER_INTEGER;
             if (param.get_type() != correctType) {
@@ -1506,9 +1491,6 @@ ZedCamera::callback_paramChange(std::vector<rclcpp::Parameter> parameters)
             RCLCPP_INFO_STREAM(get_logger(),
                 "Parameter '" << param.get_name()
                               << "' correctly set to " << val);
-            result.successful = true;
-            result.reason = param.get_name() + " correctly set.";
-            return result;
         } else if (param.get_name() == "video.auto_exposure_gain") {
             rclcpp::ParameterType correctType = rclcpp::ParameterType::PARAMETER_BOOL;
             if (param.get_type() != correctType) {
@@ -1529,9 +1511,6 @@ ZedCamera::callback_paramChange(std::vector<rclcpp::Parameter> parameters)
             RCLCPP_INFO_STREAM(get_logger(),
                 "Parameter '" << param.get_name()
                               << "' correctly set to " << val);
-            result.successful = true;
-            result.reason = param.get_name() + " correctly set.";
-            return result;
         } else if (param.get_name() == "video.exposure") {
             rclcpp::ParameterType correctType = rclcpp::ParameterType::PARAMETER_INTEGER;
             if (param.get_type() != correctType) {
@@ -1556,9 +1535,6 @@ ZedCamera::callback_paramChange(std::vector<rclcpp::Parameter> parameters)
             RCLCPP_INFO_STREAM(get_logger(),
                 "Parameter '" << param.get_name()
                               << "' correctly set to " << val);
-            result.successful = true;
-            result.reason = param.get_name() + " correctly set.";
-            return result;
         } else if (param.get_name() == "video.gain") {
             rclcpp::ParameterType correctType = rclcpp::ParameterType::PARAMETER_INTEGER;
             if (param.get_type() != correctType) {
@@ -1583,9 +1559,6 @@ ZedCamera::callback_paramChange(std::vector<rclcpp::Parameter> parameters)
             RCLCPP_INFO_STREAM(get_logger(),
                 "Parameter '" << param.get_name()
                               << "' correctly set to " << val);
-            result.successful = true;
-            result.reason = param.get_name() + " correctly set.";
-            return result;
         } else if (param.get_name() == "video.auto_whitebalance") {
             rclcpp::ParameterType correctType = rclcpp::ParameterType::PARAMETER_BOOL;
             if (param.get_type() != correctType) {
@@ -1606,9 +1579,6 @@ ZedCamera::callback_paramChange(std::vector<rclcpp::Parameter> parameters)
             RCLCPP_INFO_STREAM(get_logger(),
                 "Parameter '" << param.get_name()
                               << "' correctly set to " << val);
-            result.successful = true;
-            result.reason = param.get_name() + " correctly set.";
-            return result;
         } else if (param.get_name() == "video.whitebalance_temperature") {
             rclcpp::ParameterType correctType = rclcpp::ParameterType::PARAMETER_INTEGER;
             if (param.get_type() != correctType) {
@@ -1633,9 +1603,6 @@ ZedCamera::callback_paramChange(std::vector<rclcpp::Parameter> parameters)
             RCLCPP_INFO_STREAM(get_logger(),
                 "Parameter '" << param.get_name()
                               << "' correctly set to " << val);
-            result.successful = true;
-            result.reason = param.get_name() + " correctly set.";
-            return result;
         } else if (param.get_name() == "depth.point_cloud_freq") {
             rclcpp::ParameterType correctType = rclcpp::ParameterType::PARAMETER_DOUBLE;
             if (param.get_type() != correctType) {
@@ -1660,9 +1627,6 @@ ZedCamera::callback_paramChange(std::vector<rclcpp::Parameter> parameters)
             RCLCPP_INFO_STREAM(get_logger(),
                 "Parameter '" << param.get_name()
                               << "' correctly set to " << val);
-            result.successful = true;
-            result.reason = param.get_name() + " correctly set.";
-            return result;
         } else if (param.get_name() == "depth.depth_confidence") {
             rclcpp::ParameterType correctType = rclcpp::ParameterType::PARAMETER_INTEGER;
             if (param.get_type() != correctType) {
@@ -1686,9 +1650,6 @@ ZedCamera::callback_paramChange(std::vector<rclcpp::Parameter> parameters)
             RCLCPP_INFO_STREAM(get_logger(),
                 "Parameter '" << param.get_name()
                               << "' correctly set to " << val);
-            result.successful = true;
-            result.reason = param.get_name() + " correctly set.";
-            return result;
         } else if (param.get_name() == "depth.depth_texture_conf") {
             rclcpp::ParameterType correctType = rclcpp::ParameterType::PARAMETER_INTEGER;
             if (param.get_type() != correctType) {
@@ -1712,9 +1673,6 @@ ZedCamera::callback_paramChange(std::vector<rclcpp::Parameter> parameters)
             RCLCPP_INFO_STREAM(get_logger(),
                 "Parameter '" << param.get_name()
                               << "' correctly set to " << val);
-            result.successful = true;
-            result.reason = param.get_name() + " correctly set.";
-            return result;
         } else if (param.get_name() == "depth.remove_saturated_areas") {
             rclcpp::ParameterType correctType = rclcpp::ParameterType::PARAMETER_BOOL;
             if (param.get_type() != correctType) {
@@ -1730,9 +1688,6 @@ ZedCamera::callback_paramChange(std::vector<rclcpp::Parameter> parameters)
                 "Parameter '"
                     << param.get_name() << "' correctly set to "
                     << (mRemoveSatAreas ? "TRUE" : "FALSE"));
-            result.successful = true;
-            result.reason = param.get_name() + " correctly set.";
-            return result;
         } else if (param.get_name() == "mapping.fused_pointcloud_freq") {
             rclcpp::ParameterType correctType = rclcpp::ParameterType::PARAMETER_DOUBLE;
             if (param.get_type() != correctType) {
@@ -1757,9 +1712,6 @@ ZedCamera::callback_paramChange(std::vector<rclcpp::Parameter> parameters)
             RCLCPP_INFO_STREAM(get_logger(),
                 "Parameter '" << param.get_name()
                               << "' correctly set to " << val);
-            result.successful = true;
-            result.reason = param.get_name() + " correctly set.";
-            return result;
         } else if (param.get_name() == "object_detection.confidence_threshold") {
             rclcpp::ParameterType correctType = rclcpp::ParameterType::PARAMETER_DOUBLE;
             if (param.get_type() != correctType) {
@@ -1783,9 +1735,6 @@ ZedCamera::callback_paramChange(std::vector<rclcpp::Parameter> parameters)
             RCLCPP_INFO_STREAM(get_logger(),
                 "Parameter '" << param.get_name()
                               << "' correctly set to " << val);
-            result.successful = true;
-            result.reason = param.get_name() + " correctly set.";
-            return result;
         } else if (param.get_name() == "object_detection.mc_people") {
             rclcpp::ParameterType correctType = rclcpp::ParameterType::PARAMETER_BOOL;
             if (param.get_type() != correctType) {
@@ -1801,9 +1750,6 @@ ZedCamera::callback_paramChange(std::vector<rclcpp::Parameter> parameters)
                 "Parameter '"
                     << param.get_name() << "' correctly set to "
                     << (mObjDetPeopleEnable ? "TRUE" : "FALSE"));
-            result.successful = true;
-            result.reason = param.get_name() + " correctly set.";
-            return result;
         } else if (param.get_name() == "object_detection.mc_vehicle") {
             rclcpp::ParameterType correctType = rclcpp::ParameterType::PARAMETER_BOOL;
             if (param.get_type() != correctType) {
@@ -1819,9 +1765,6 @@ ZedCamera::callback_paramChange(std::vector<rclcpp::Parameter> parameters)
                 "Parameter '"
                     << param.get_name() << "' correctly set to "
                     << (mObjDetVehiclesEnable ? "TRUE" : "FALSE"));
-            result.successful = true;
-            result.reason = param.get_name() + " correctly set.";
-            return result;
         } else if (param.get_name() == "object_detection.mc_bag") {
             rclcpp::ParameterType correctType = rclcpp::ParameterType::PARAMETER_BOOL;
             if (param.get_type() != correctType) {
@@ -1837,9 +1780,6 @@ ZedCamera::callback_paramChange(std::vector<rclcpp::Parameter> parameters)
                 "Parameter '"
                     << param.get_name() << "' correctly set to "
                     << (mObjDetBagsEnable ? "TRUE" : "FALSE"));
-            result.successful = true;
-            result.reason = param.get_name() + " correctly set.";
-            return result;
         } else if (param.get_name() == "object_detection.mc_animal") {
             rclcpp::ParameterType correctType = rclcpp::ParameterType::PARAMETER_BOOL;
             if (param.get_type() != correctType) {
@@ -1855,9 +1795,6 @@ ZedCamera::callback_paramChange(std::vector<rclcpp::Parameter> parameters)
                 "Parameter '"
                     << param.get_name() << "' correctly set to "
                     << (mObjDetAnimalsEnable ? "TRUE" : "FALSE"));
-            result.successful = true;
-            result.reason = param.get_name() + " correctly set.";
-            return result;
         } else if (param.get_name() == "object_detection.mc_electronics") {
             rclcpp::ParameterType correctType = rclcpp::ParameterType::PARAMETER_BOOL;
             if (param.get_type() != correctType) {
@@ -1873,9 +1810,6 @@ ZedCamera::callback_paramChange(std::vector<rclcpp::Parameter> parameters)
                 "Parameter '"
                     << param.get_name() << "' correctly set to "
                     << (mObjDetElectronicsEnable ? "TRUE" : "FALSE"));
-            result.successful = true;
-            result.reason = param.get_name() + " correctly set.";
-            return result;
         } else if (param.get_name() == "object_detection.mc_fruit_vegetable") {
             rclcpp::ParameterType correctType = rclcpp::ParameterType::PARAMETER_BOOL;
             if (param.get_type() != correctType) {
@@ -1891,9 +1825,6 @@ ZedCamera::callback_paramChange(std::vector<rclcpp::Parameter> parameters)
                 "Parameter '"
                     << param.get_name() << "' correctly set to "
                     << (mObjDetFruitsEnable ? "TRUE" : "FALSE"));
-            result.successful = true;
-            result.reason = param.get_name() + " correctly set.";
-            return result;
         } else if (param.get_name() == "object_detection.mc_sport") {
             rclcpp::ParameterType correctType = rclcpp::ParameterType::PARAMETER_BOOL;
             if (param.get_type() != correctType) {
@@ -1909,16 +1840,9 @@ ZedCamera::callback_paramChange(std::vector<rclcpp::Parameter> parameters)
                 "Parameter '"
                     << param.get_name() << "' correctly set to "
                     << (mObjDetSportEnable ? "TRUE" : "FALSE"));
-            result.successful = true;
-            result.reason = param.get_name() + " correctly set.";
-            return result;
-        } else {
-            result.successful = true;
-            result.reason = param.get_name() + " is not a dynamic parameter";
         }
     }
 
-    RCLCPP_WARN_STREAM(get_logger(), result.reason);
     return result;
 }
 


### PR DESCRIPTION
This PR does a couple of things:
1. Sets read_only flag in parameter descriptors for non-dynamic parameters.

    This leaves checking if parameter is dynamic to the Parameter Server implementation. It also allows tools like `rqt_dynamic_reconfigure` to gray out non-dynamic parameters.
2. Doesn't fail the on set parameter callback for unknown parameters.

    As the read_only flag is now checked before executing the parameter callback, we don't have to assume any parameter we don't know about is not dynamic. This actually fixes the problem I had with compressed image transport plugin as I was getting errors in form of:
    ```
    zed2.left_raw.image_raw_color.format is not a dynamic parameter
    ```
    With this change and [image_common](https://github.com/ros-perception/image_common/tree/foxy) compiled from source, I can finally use compressed image transport.
3. Fails the parameter change when trying to change multiple parameters atomically.

    As the current implementation of the on set parameter callback does not support changing multiple parameters atomically, I made sure the callback fails without trying to change any parameter in such case.