### PR TITLE
Extra parameters file

### DIFF
--- a/zed_wrapper/launch/include/zed_camera.launch.py
+++ b/zed_wrapper/launch/include/zed_camera.launch.py
@@ -80,6 +80,8 @@ def launch_setup(context, *args, **kwargs):
     publish_map_tf = LaunchConfiguration('publish_map_tf')
     xacro_path = LaunchConfiguration('xacro_path')
 
+    ros_parameters_path = LaunchConfiguration('ros_parameters_path')
+
     gnss_frame = LaunchConfiguration('gnss_frame')
 
     camera_name_val = camera_name.perform(context)
@@ -149,7 +151,8 @@ def launch_setup(context, *args, **kwargs):
                 'pos_tracking.publish_tf': publish_tf,
                 'pos_tracking.publish_map_tf': publish_map_tf,
                 'pos_tracking.publish_imu_tf': publish_tf
-            }
+            },
+            ros_parameters_path,
         ]
     )
 
@@ -202,6 +205,10 @@ def generate_launch_description():
                 'xacro_path',
                 default_value=TextSubstitution(text=default_xacro_path),
                 description='Path to the camera URDF file as a xacro file.'),
+            DeclareLaunchArgument(
+                'ros_parameters_path',
+                default_value='',
+                description='The path to an additional parameters file to load into the core node'),
             DeclareLaunchArgument(
                 'svo_path',
                 default_value=TextSubstitution(text="live"),


### PR DESCRIPTION
Right now if you want to change a ROS parameter while using `zed_camera.launch.py` , you either have to do it manually after the node is running, or it has to be one of the handful of parameters that there are launch arguments for. 

This PR adds an additional path that will be loaded into the camera node as ROS parameters. By default, the string is empty and no extra parameters will be loaded. However, you can set it to a custom yaml file and they will be loaded. 

e.g. 

```
    ld.add_action(IncludeLaunchDescription(
        launch_description_source=PythonLaunchDescriptionSource([
            get_package_share_directory('zed_wrapper'),
            '/launch/include/zed_camera.launch.py'
        ]),
        launch_arguments={
            'ros_parameters_path': [get_package_share_directory('some_package'), '/config/zed.yaml'],
        }.items()
    ))
```
where some_package/config/zed.yaml could look like:
```
/**:
    ros__parameters:
        body_tracking.body_format: BODY_34

```
specifying only the parameters that are different from `common.yaml`

