### PR TITLE
Enable choosing different resolution for depth images than for RGB

### DIFF
--- a/zed_components/src/zed_camera/include/zed_camera_component.hpp
+++ b/zed_components/src/zed_camera/include/zed_camera_component.hpp
@@ -266,7 +266,8 @@ private:
   int mVerbose = 1;
   int mGpuId = -1;
   sl::RESOLUTION mCamResol = sl::RESOLUTION::HD720;  // Default resolution: RESOLUTION_HD720
-  PubRes mPubResolution = MEDIUM;  // Use native DNN resolution for NEURAL depth to improve speed and quality.
+  PubRes mPubImgResolution = MEDIUM;
+  PubRes mPubDepthResolution = MEDIUM;  // Use native DNN resolution for NEURAL depth to improve speed and quality.
   sl::DEPTH_MODE mDepthMode = sl::DEPTH_MODE::PERFORMANCE;  // Default depth mode: DEPTH_MODE_PERFORMANCE
   bool mDepthDisabled =
     false;  // Indicates if depth calculation is not required (DEPTH_MODE::NONE se for )
@@ -431,7 +432,8 @@ private:
   // ----> Stereolabs Mat Info
   int mCamWidth;   // Camera frame width
   int mCamHeight;  // Camera frame height
-  sl::Resolution mMatResol;
+  sl::Resolution mMatImgResol;
+  sl::Resolution mMatDepthResol;
   // <---- Stereolabs Mat Info
 
   // Camera IMU transform


### PR DESCRIPTION
This PR enables choosing separate resolutions for the depth and RGB images. This allows improving performance e.g. if you need only medium depth resolution but high RGB resolution.