### PR TITLE
Remove depth png image write on grab loop

### DIFF
--- a/zed_components/src/zed_camera/src/zed_camera_component.cpp
+++ b/zed_components/src/zed_camera/src/zed_camera_component.cpp
@@ -5886,7 +5886,6 @@ void ZedCamera::retrieveVideoDepth()
       sl::ERROR_CODE::SUCCESS ==
       mZed.retrieveMeasure(mMatDepth, sl::MEASURE::DEPTH, sl::MEM::CPU, mMatResol);
     mSdkGrabTS = mMatDepth.timestamp;
-    mMatDepth.write("depth_map.png");
   }
   if (mDisparitySubnumber > 0) {
     DEBUG_STREAM_VD("Retrieving Disparity");


### PR DESCRIPTION
When doing a performance test I found this image write taking most of the CPU cycles for the grab thread loop. Attaching the CPU FlameGraph for reference.

![zedGrab_flamegraph](https://github.com/stereolabs/zed-ros2-wrapper/assets/100617324/121ab721-a1c5-476e-b591-8a4f4c8899a3)
