### PR TITLE
Migrate static member function variables to normal member variables

### DIFF
--- a/zed_components/src/zed_camera/include/zed_camera_component.hpp
+++ b/zed_components/src/zed_camera/include/zed_camera_component.hpp
@@ -472,9 +472,13 @@ private:
 
   // ----> TF Transforms Flags
   bool mSensor2BaseTransfValid = false;
+  bool mSensor2BaseTransfFirstError = true;
   bool mSensor2CameraTransfValid = false;
+  bool mSensor2CameraTransfFirstError = true;
   bool mCamera2BaseTransfValid = false;
+  bool mCamera2BaseTransfFirstError = true;
   bool mGnss2BaseTransfValid = false;
+  bool mGnss2BaseTransfFirstError = true;
   bool mMap2UtmTransfValid = false;
 
   std::atomic_uint16_t mAiInstanceID;
@@ -571,6 +575,11 @@ private:
 
   float mMinDepth = 0.0f;
   float mMaxDepth = 0.0f;
+
+  uint64_t mLastTs_gnssNsec;
+
+  int mHitPtId;
+  int mPlaneMeshId;
   // <---- Publisher variables
 
   // ----> Point cloud variables
@@ -693,6 +702,33 @@ private:
   bool mBaroPublishing = false;
   bool mObjDetSubscribed = false;
   bool mBodyTrkSubscribed = false;
+
+  sl_tools::StopWatch mImuTfFreqTimer;
+  sl_tools::StopWatch mGrabFreqTimer;
+  sl_tools::StopWatch mImuFreqTimer;
+  sl_tools::StopWatch mBaroFreqTimer;
+  sl_tools::StopWatch mMagFreqTimer;
+  sl_tools::StopWatch mOdomFreqTimer;
+  sl_tools::StopWatch mPoseFreqTimer;
+  sl_tools::StopWatch mPcPubFreqTimer;
+  sl_tools::StopWatch mVdPubFreqTimer;
+  sl_tools::StopWatch mSensPubFreqTimer;
+  sl_tools::StopWatch mOdFreqTimer;
+  sl_tools::StopWatch mBtFreqTimer;
+  sl_tools::StopWatch mPcFreqTimer;
+  sl_tools::StopWatch mGnssFixFreqTimer;
+
+  rclcpp::Time mLastTs_imu;
+  rclcpp::Time mLastTs_baro;
+  rclcpp::Time mLastTs_mag;
+  rclcpp::Time mLastTs_odom;
+  rclcpp::Time mLastTs_poseTf;
+  rclcpp::Time mLastTs_pc;
+  rclcpp::Time mLastTs_fusedPc;
+
+  sl::Timestamp mLastTs_sdkGrab;  // Used to calculate stable publish frequency
+
+  int mDiagnosticOverloadCount;
 
   diagnostic_updater::Updater mDiagUpdater;  // Diagnostic Updater
 


### PR DESCRIPTION
# Summary
This PR migrates all of the static variables used throughout the component to class member variables to avoid quiet corruption of logic and timestamps when using the ZED node as a ComposableNode (i.e. multiple cameras in a single process).

This PR is a pure refactor, no logic changes, just names and where variables live.

# Background
The current camera component has a ton of static variables. When used as a node in ROS that's fine, things work as expected. That works for a single camera, however if you have multiple cameras you can't run them in separate processes due to [this sdk bug](https://community.stereolabs.com/t/multi-processes-multi-cameras/3186) (which I also personally lost a lot of time to until I found that post) so your only option is to put them in a single process. ROS2 has [Composable Nodes](https://docs.ros.org/en/foxy/How-To-Guides/Launching-composable-nodes.html) for just such an occasion. It uses the normal Node interface, it's basically a launch configuration option about if you want to run your nodes as separate processes or one process. However static variables, even in class member functions, only have 1 instantiation _at the process level_. So when I changed my configuration to run everything in one process one version of these static variables were being shared between all of my cameras and quietly causing a bunch of maddening side effects that took forever to chase down.

Without this PR using multiple ZEDs in ROS is impossible, you either use separate nodes and your cameras fail to open reliably (sdk bug which will be fixed at some point but isn't as of 4.0.6) or use a ComponentManager to run everything in one process and get quietly corrupted timestamps/side effects.

This fixes the issue I was seeing where my RGB and Depth timestamps were out of sync when multiple cameras are running (and who knows what other weird side effects I was missing). Figured I'd try and save some folks the work of re-doing all of the same refactoring.

### Note
There were two cases where I don't know why `static` variables were used as the variables were written to in the function before ever being read (i.e. they were functionally identical to local variables) so I didn't make member variables from them, I just removed the `static` modifer. See `ts_rgb` and `ts_depth` for an example.