### PR TITLE
specify branch for zed-ros2-interfaces submodule

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,3 +1,4 @@
 [submodule "zed-ros2-interfaces"]
 	path = zed-ros2-interfaces
 	url = https://github.com/stereolabs/zed-ros2-interfaces.git
+	branch = main


### PR DESCRIPTION
In older versions of git, the mismatch of "master" vs "main" as being the primary branch in zed-ros2-wrapper and zed-ros2-interfaces respectively causes some issues with recursive submodule checkout.