### PR TITLE
Bugfix for using incorrect time when publishing from SVO

### DIFF
--- a/zed_components/src/zed_camera/src/zed_camera_component.cpp
+++ b/zed_components/src/zed_camera/src/zed_camera_component.cpp
@@ -5183,11 +5183,11 @@ void ZedCamera::threadFunc_zedGrab()
 
       // ----> Timestamp
       if (mSvoMode) {
-        mFrameTimestamp = sl_tools::slTime2Ros(mZed.getTimestamp(sl::TIME_REFERENCE::CURRENT));
+        mFrameTimestamp = sl_tools::slTime2Ros(mZed.getTimestamp(sl::TIME_REFERENCE::IMAGE));
       } else if (mSimEnabled) {
         mFrameTimestamp = get_clock()->now(); // We must use the simulation time, not the SDK time
       } else {
-        mFrameTimestamp = sl_tools::slTime2Ros(mZed.getTimestamp(sl::TIME_REFERENCE::IMAGE));
+        mFrameTimestamp = sl_tools::slTime2Ros(mZed.getTimestamp(sl::TIME_REFERENCE::CURRENT));
       }
       // <---- Timestamp
 


### PR DESCRIPTION
We were using the SVO mode to convert svo-files into rosbags - a very helpful feature of the driver. We noticed, that the timestamps are not matching the time of recording but the time of the conversion. It seems like an incorrect if-statement was the reason for that. 