### PR TITLE
Fix camera resolution on foxy-humble-v3.8.2

### DIFF
--- a/zed_components/src/zed_camera/src/zed_camera_component.cpp
+++ b/zed_components/src/zed_camera/src/zed_camera_component.cpp
@@ -2616,13 +2616,13 @@ bool ZedCamera::startCamera()
       break;
 
     case PubRes::HD1080:
-      pub_w = sl::getResolution(sl::RESOLUTION::HD2K).width;
-      pub_h = sl::getResolution(sl::RESOLUTION::HD2K).height;
+      pub_w = sl::getResolution(sl::RESOLUTION::HD1080).width;
+      pub_h = sl::getResolution(sl::RESOLUTION::HD1080).height;
       break;
 
     case PubRes::HD720:
-      pub_w = sl::getResolution(sl::RESOLUTION::HD2K).width;
-      pub_h = sl::getResolution(sl::RESOLUTION::HD2K).height;
+      pub_w = sl::getResolution(sl::RESOLUTION::HD720).width;
+      pub_h = sl::getResolution(sl::RESOLUTION::HD720).height;
       break;
 
     case PubRes::MEDIUM:
@@ -2631,8 +2631,8 @@ bool ZedCamera::startCamera()
       break;
 
     case PubRes::VGA:
-      pub_w = sl::getResolution(sl::RESOLUTION::HD2K).width;
-      pub_h = sl::getResolution(sl::RESOLUTION::HD2K).height;
+      pub_w = sl::getResolution(sl::RESOLUTION::VGA).width;
+      pub_h = sl::getResolution(sl::RESOLUTION::VGA).height;
       break;
 
     case PubRes::LOW:


### PR DESCRIPTION
For the poor souls like me who are still working on the foxy-humble-v3.8.2 tag I have found a minor issue when selecting the camera resolution.
The commit speaks for itself.

I hope you will find a way to integrate it since not all the developers are working on the 4.x version.

Cheers!
Mattia