### PR TITLE
Fixing Transform Inversion Logic in UTM Conversion

### DIFF
--- a/zed_components/src/zed_camera/src/zed_camera_component.cpp
+++ b/zed_components/src/zed_camera/src/zed_camera_component.cpp
@@ -7811,8 +7811,8 @@ void ZedCamera::processGeoPose()
 
     // conversion from Transform to message
     transformStamped.transform = mUtmAsParent ?
-      (tf2::toMsg(mMap2UtmTransf.inverse())) :
-      (tf2::toMsg(mMap2UtmTransf));
+      (tf2::toMsg(mMap2UtmTransf)) :
+      (tf2::toMsg(mMap2UtmTransf.inverse()));
 
     mTfBroadcaster->sendTransform(transformStamped);
   }


### PR DESCRIPTION
This pull request addresses an issue with the transformation logic in the UTM to MAP conversion process. The original implementation incorrectly inverted the transform when mUtmAsParent flag was set to true.