### PR TITLE
Created SaveAreaDatabase Service

### DIFF
--- a/zed_components/src/zed_camera/include/sl_types.hpp
+++ b/zed_components/src/zed_camera/include/sl_types.hpp
@@ -57,6 +57,7 @@
 #include <zed_interfaces/msg/plane_stamped.hpp>
 #include <zed_interfaces/msg/pos_track_status.hpp>
 #include <zed_interfaces/srv/set_pose.hpp>
+#include <zed_interfaces/srv/save_area_database.hpp>
 #include <zed_interfaces/srv/set_roi.hpp>
 #include <zed_interfaces/srv/start_svo_rec.hpp>
 
@@ -157,6 +158,7 @@ typedef std::unique_ptr<visualization_msgs::msg::Marker> markerMsgPtr;
 typedef rclcpp::Service<std_srvs::srv::Trigger>::SharedPtr resetOdomSrvPtr;
 typedef rclcpp::Service<std_srvs::srv::Trigger>::SharedPtr resetPosTrkSrvPtr;
 typedef rclcpp::Service<zed_interfaces::srv::SetPose>::SharedPtr setPoseSrvPtr;
+typedef rclcpp::Service<zed_interfaces::srv::SaveAreaDatabase>::SharedPtr saveAreaDatabaseSrvPtr;
 typedef rclcpp::Service<std_srvs::srv::SetBool>::SharedPtr enableObjDetPtr;
 typedef rclcpp::Service<std_srvs::srv::SetBool>::SharedPtr enableBodyTrkPtr;
 typedef rclcpp::Service<std_srvs::srv::SetBool>::SharedPtr enableMappingPtr;

--- a/zed_components/src/zed_camera/include/zed_camera_component.hpp
+++ b/zed_components/src/zed_camera/include/zed_camera_component.hpp
@@ -103,6 +103,10 @@ protected:
     const std::shared_ptr<rmw_request_id_t> request_header,
     const std::shared_ptr<zed_interfaces::srv::SetPose_Request> req,
     std::shared_ptr<zed_interfaces::srv::SetPose_Response> res);
+  void callback_saveAreaDatabase(
+    const std::shared_ptr<rmw_request_id_t> request_header,
+    const std::shared_ptr<zed_interfaces::srv::SaveAreaDatabase_Request> req,
+    std::shared_ptr<zed_interfaces::srv::SaveAreaDatabase_Response> res);
   void callback_enableObjDet(
     const std::shared_ptr<rmw_request_id_t> request_header,
     const std::shared_ptr<std_srvs::srv::SetBool_Request> req,
@@ -816,6 +820,7 @@ private:
   resetOdomSrvPtr mResetOdomSrv;
   resetPosTrkSrvPtr mResetPosTrkSrv;
   setPoseSrvPtr mSetPoseSrv;
+  saveAreaDatabaseSrvPtr mSaveAreaDatabaseSrv;
   enableObjDetPtr mEnableObjDetSrv;
   enableBodyTrkPtr mEnableBodyTrkSrv;
   enableMappingPtr mEnableMappingSrv;
@@ -833,6 +838,7 @@ private:
   const std::string mSrvResetOdomName = "reset_odometry";
   const std::string mSrvResetPoseName = "reset_pos_tracking";
   const std::string mSrvSetPoseName = "set_pose";
+  const std::string mSrvSaveAreaDatabase = "save_area_database";
   const std::string mSrvEnableObjDetName = "enable_obj_det";
   const std::string mSrvEnableBodyTrkName = "enable_body_trk";
   const std::string mSrvEnableMappingName = "enable_mapping";

--- a/zed_wrapper/config/common.yaml
+++ b/zed_wrapper/config/common.yaml
@@ -20,7 +20,7 @@
             camera_max_reconnect: 5
             camera_flip: false
             serial_number: 0 # usually overwritten by launch file
-            pub_resolution: "CUSTOM" # The resolution used for output. 'NATIVE' to use the same `general.grab_resolution` - `CUSTOM` to apply the `general.pub_downscale_factor` downscale factory to reduce bandwidth in transmission
+            pub_resolution: "NATIVE" # The resolution used for output. 'NATIVE' to use the same `general.grab_resolution` - `CUSTOM` to apply the `general.pub_downscale_factor` downscale factory to reduce bandwidth in transmission
             pub_downscale_factor: 2.0 # rescale factor used to rescale image before publishing when 'pub_resolution' is 'CUSTOM'
             pub_frame_rate: 30.0 # frequency of publishing of visual images and depth images
             gpu_id: -1
@@ -34,7 +34,7 @@
             sharpness: 4 # [DYNAMIC]
             gamma: 8 # [DYNAMIC]
             auto_exposure_gain: true # [DYNAMIC]
-            exposure: 80 # [DYNAMIC]i
+            exposure: 80 # [DYNAMIC]
             gain: 80 # [DYNAMIC]
             auto_whitebalance: true # [DYNAMIC]
             whitebalance_temperature: 42 # [DYNAMIC] - [28,65] works only if `auto_whitebalance` is false
@@ -54,7 +54,7 @@
             apply_to_spatial_mapping: true # Apply ROI to spatial mapping processing
 
         depth:
-            depth_mode: "NEURAL" # Matches the ZED SDK setting: 'NONE', 'PERFORMANCE', 'QUALITY', 'ULTRA', 'NEURAL', 'NEURAL_PLUS' - Note: if 'NONE' all the modules that requires depth extraction are disabled by default (Pos. Tracking, Obj. Detection, Mapping, ...)
+            depth_mode: "ULTRA" # Matches the ZED SDK setting: 'NONE', 'PERFORMANCE', 'QUALITY', 'ULTRA', 'NEURAL', 'NEURAL_PLUS' - Note: if 'NONE' all the modules that requires depth extraction are disabled by default (Pos. Tracking, Obj. Detection, Mapping, ...)
             depth_stabilization: 1 # Forces positional tracking to start if major than 0 - Range: [0,100]
             openni_depth_mode: false # 'false': 32bit float [meters], 'true': 16bit unsigned int [millimeters]
             point_cloud_freq: 10.0 # [DYNAMIC] - frequency of the pointcloud publishing (equal or less to `grab_frame_rate` value)
@@ -70,7 +70,7 @@
             publish_map_tf: true # [usually overwritten by launch file] publish `map -> odom` TF
             map_frame: "map"
             odometry_frame: "odom"
-            area_memory_db_path: "/workspaces/temp_ws/database.area"
+            area_memory_db_path: ""
             area_memory: true # Enable to detect loop closure
             reset_odom_with_loop_closure: true # Re-initialize odometry to the last valid pose when loop closure happens (reset camera odometry drift)
             depth_min_range: 0.0 # Set this value for removing fixed zones of the robot in the FoV of the camerafrom the visual odometry evaluation
@@ -100,7 +100,7 @@
             target_yaw_uncertainty: 1e-2 # defines the target yaw uncertainty at which the calibration process between GNSS and VIO concludes. The unit of this parameter is in radian. By default, the threshold is set at 0.1 radians.
 
         mapping:
-            mapping_enabled: true # True to enable mapping and fused point cloud pubblication
+            mapping_enabled: false # True to enable mapping and fused point cloud pubblication
             resolution: 0.05 # maps resolution in meters [min: 0.01f - max: 0.2f]
             max_mapping_range: 5.0 # maximum depth range while mapping in meters (-1 for automatic calculation) [2.0, 20.0]
             fused_pointcloud_freq: 1.0 # frequency of the publishing of the fused colored point cloud

--- a/zed_wrapper/config/common.yaml
+++ b/zed_wrapper/config/common.yaml
@@ -20,7 +20,7 @@
             camera_max_reconnect: 5
             camera_flip: false
             serial_number: 0 # usually overwritten by launch file
-            pub_resolution: "NATIVE" # The resolution used for output. 'NATIVE' to use the same `general.grab_resolution` - `CUSTOM` to apply the `general.pub_downscale_factor` downscale factory to reduce bandwidth in transmission
+            pub_resolution: "CUSTOM" # The resolution used for output. 'NATIVE' to use the same `general.grab_resolution` - `CUSTOM` to apply the `general.pub_downscale_factor` downscale factory to reduce bandwidth in transmission
             pub_downscale_factor: 2.0 # rescale factor used to rescale image before publishing when 'pub_resolution' is 'CUSTOM'
             pub_frame_rate: 30.0 # frequency of publishing of visual images and depth images
             gpu_id: -1
@@ -34,7 +34,7 @@
             sharpness: 4 # [DYNAMIC]
             gamma: 8 # [DYNAMIC]
             auto_exposure_gain: true # [DYNAMIC]
-            exposure: 80 # [DYNAMIC]
+            exposure: 80 # [DYNAMIC]i
             gain: 80 # [DYNAMIC]
             auto_whitebalance: true # [DYNAMIC]
             whitebalance_temperature: 42 # [DYNAMIC] - [28,65] works only if `auto_whitebalance` is false
@@ -54,7 +54,7 @@
             apply_to_spatial_mapping: true # Apply ROI to spatial mapping processing
 
         depth:
-            depth_mode: "ULTRA" # Matches the ZED SDK setting: 'NONE', 'PERFORMANCE', 'QUALITY', 'ULTRA', 'NEURAL', 'NEURAL_PLUS' - Note: if 'NONE' all the modules that requires depth extraction are disabled by default (Pos. Tracking, Obj. Detection, Mapping, ...)
+            depth_mode: "NEURAL" # Matches the ZED SDK setting: 'NONE', 'PERFORMANCE', 'QUALITY', 'ULTRA', 'NEURAL', 'NEURAL_PLUS' - Note: if 'NONE' all the modules that requires depth extraction are disabled by default (Pos. Tracking, Obj. Detection, Mapping, ...)
             depth_stabilization: 1 # Forces positional tracking to start if major than 0 - Range: [0,100]
             openni_depth_mode: false # 'false': 32bit float [meters], 'true': 16bit unsigned int [millimeters]
             point_cloud_freq: 10.0 # [DYNAMIC] - frequency of the pointcloud publishing (equal or less to `grab_frame_rate` value)
@@ -70,7 +70,7 @@
             publish_map_tf: true # [usually overwritten by launch file] publish `map -> odom` TF
             map_frame: "map"
             odometry_frame: "odom"
-            area_memory_db_path: ""
+            area_memory_db_path: "/workspaces/temp_ws/database.area"
             area_memory: true # Enable to detect loop closure
             reset_odom_with_loop_closure: true # Re-initialize odometry to the last valid pose when loop closure happens (reset camera odometry drift)
             depth_min_range: 0.0 # Set this value for removing fixed zones of the robot in the FoV of the camerafrom the visual odometry evaluation
@@ -100,7 +100,7 @@
             target_yaw_uncertainty: 1e-2 # defines the target yaw uncertainty at which the calibration process between GNSS and VIO concludes. The unit of this parameter is in radian. By default, the threshold is set at 0.1 radians.
 
         mapping:
-            mapping_enabled: false # True to enable mapping and fused point cloud pubblication
+            mapping_enabled: true # True to enable mapping and fused point cloud pubblication
             resolution: 0.05 # maps resolution in meters [min: 0.01f - max: 0.2f]
             max_mapping_range: 5.0 # maximum depth range while mapping in meters (-1 for automatic calculation) [2.0, 20.0]
             fused_pointcloud_freq: 1.0 # frequency of the publishing of the fused colored point cloud

--- a/zed_wrapper/config/zedx.yaml
+++ b/zed_wrapper/config/zedx.yaml
@@ -6,7 +6,7 @@
         general:
           camera_model: 'zedx'
           camera_name: 'zedx' # usually overwritten by launch file
-          grab_resolution: 'HD1200' # The native camera grab resolution. 'HD1200', 'HD1080', 'SVGA', 'AUTO'
+          grab_resolution: 'HD1080' # The native camera grab resolution. 'HD1200', 'HD1080', 'SVGA', 'AUTO'
           grab_frame_rate: 30 # ZED SDK internal grabbing rate (HD1200/HD1080: 60, 30, 15 - SVGA: 120, 60, 30, 15)
 
         video:

--- a/zed_wrapper/config/zedx.yaml
+++ b/zed_wrapper/config/zedx.yaml
@@ -6,7 +6,7 @@
         general:
           camera_model: 'zedx'
           camera_name: 'zedx' # usually overwritten by launch file
-          grab_resolution: 'HD1080' # The native camera grab resolution. 'HD1200', 'HD1080', 'SVGA', 'AUTO'
+          grab_resolution: 'HD1200' # The native camera grab resolution. 'HD1200', 'HD1080', 'SVGA', 'AUTO'
           grab_frame_rate: 30 # ZED SDK internal grabbing rate (HD1200/HD1080: 60, 30, 15 - SVGA: 120, 60, 30, 15)
 
         video:
@@ -25,4 +25,3 @@
         depth:
           min_depth: 0.3 # Min: 0.3, Max: 3.0
           max_depth: 10.0 # Max: 20.0
-


### PR DESCRIPTION
### Pull Request Description

**Overview:** 
Enhances `zed_interfaces` by adding `getareadatabase`, a new service facilitating area database retrieval via the ZED ROS 2 wrapper.

**Changes:**

- Added `getareadatabase` service definition to `zed_interfaces`.
- Implemented service call handling in `zed_ros2_wrapper` to process requests and interact with ZED SDK.

**Details:**

- **New Service (`getareadatabase`):**
  - Defined in `zed_interfaces` for ROS 2 nodes to request ZED camera area databases.
  - Enhances interaction capabilities for localization and mapping tasks.

- **Implementation in `zed_ros2_wrapper`:**
  - Handles requests, utilizes ZED SDK for database retrieval, and sends responses to clients.

**Usage:**

- Enables dynamic area database retrieval from ZED cameras in ROS 2 applications.
- Enhances functionality for spatial awareness and mapping tasks.

**Impact:**

- Improves ZED camera integration in ROS 2, enhancing robotic perception and localization.
- Standardizes access to area databases, promoting interoperability across projects.

**Testing:**

- Tested on Stereolabs ZED Box with ZEDX stereo camera.
- Test environment used Isaac ROS docker container running Ubuntu 22.04.


**Contributor Notes:**

- Aligns with efforts to expand ZED ROS 2 wrapper functionality.
- Welcomes feedback for further optimization and refinement.