### PR TITLE
fix: desktop Dockerfile correctly updates and installs rosdep deps

### DIFF
--- a/docker/Dockerfile.desktop-humble
+++ b/docker/Dockerfile.desktop-humble
@@ -118,7 +118,7 @@ COPY tmp_sources/ ./
 WORKDIR /root/ros2_ws/
 
 RUN /bin/bash -c "source /opt/ros/$ROS_DISTRO/setup.bash && \
-  apt-get update -y || true && rosdep update \
+  apt-get update -y || true && rosdep update && \
   rosdep install --from-paths src --ignore-src -r -y && \
   colcon build --parallel-workers $(nproc) --symlink-install \
   --event-handlers console_direct+ --base-paths src \


### PR DESCRIPTION
Fixes small mistake: 2 consecutive rosdep commands aren't properly escaped in multiline bash command