### PR TITLE
Forward confidence levels of skeleton keypoints from SDK to Object message

### DIFF
--- a/zed_components/src/zed_camera/src/zed_camera_component.cpp
+++ b/zed_components/src/zed_camera/src/zed_camera_component.cpp
@@ -8499,6 +8499,10 @@ void ZedCamera::processBodies(rclcpp::Time t)
       memcpy(
         &(bodyMsg->objects[idx].skeleton_3d.keypoints[0]),
         &(body.keypoint[0]), 3 * kp_size * sizeof(float));
+
+      memcpy(
+        &(bodyMsg->objects[idx].skeleton_keypoint_confidence[0]),
+        &(body.keypoint_confidence[0]), kp_size * sizeof(float));
     }
 
     // ----------------------------------


### PR DESCRIPTION
Updated the ZED ROS2 Wrapper to forward the confidence levels of the skeleton keypoints from the ZED SDK to the ROS2 message. This change depends on the updated message definitions provided in  [https://github.com/stereolabs/zed-ros2-interfaces/pull/16](https://github.com/stereolabs/zed-ros2-interfaces/pull/16).

Making the confidence values available in ROS2 allows for applications like skeleton-based gaze detectors that require both keypoint coordinates and their associated confidence values, and could be useful for other applications.