### PR TITLE
Change ZEDM distance according to the datasheet

### DIFF
--- a/zed_wrapper/urdf/zed_macro.urdf.xacro
+++ b/zed_wrapper/urdf/zed_macro.urdf.xacro
@@ -37,7 +37,7 @@
       <xacro:property name="mono" value="false" />
     </xacro:if>
     <xacro:if value="${model == 'zedm'}">
-      <xacro:property name="baseline" value="0.06" />
+      <xacro:property name="baseline" value="0.063" />
       <xacro:property name="height" value="0.0265" />
       <xacro:property name="bottom_slope" value="0.0" /> 
       <xacro:property name="screw_offset_x" value="0.0" />


### PR DESCRIPTION
The camera baseline for ZEDM seems to be incorrect by 3mm in the `xacro` file according to the datasheet: https://cdn.sanity.io/files/s18ewfw4/staging/ebcd46896092d1ee6212b7f4d81aaa1c479c2440.pdf/ZED%20Mini%20Datasheet%20v1.1.pdf