### PR TITLE
Fixed an issue related to Gazebo not being able to find the zed mesh (.stl) files

### DIFF
--- a/zed_wrapper/urdf/zed_macro.urdf.xacro
+++ b/zed_wrapper/urdf/zed_macro.urdf.xacro
@@ -118,14 +118,14 @@
         <visual>
           <origin xyz="${screw_offset_x} 0 ${screw_offset_z}" rpy="0 0 0"/>
           <geometry>
-<mesh filename="package://zed_msgs/meshes/${model}.stl" />
+<mesh filename="$(find zed_msgs)/meshes/${model}.stl" />
           </geometry>
           <material name="${model}_mat" />
         </visual>      
         <collision>
           <origin xyz="${screw_offset_x} 0 ${screw_offset_z}" rpy="0 0 0"/>
           <geometry>
-<mesh filename="package://zed_msgs/meshes/${model}.stl" />
+<mesh filename="$(find zed_msgs)/meshes/${model}.stl" />
           </geometry>
         </collision>
       </xacro:unless>
@@ -143,14 +143,14 @@
           <visual>
             <origin xyz="0 0 0" rpy="0 0 0"/>
             <geometry>
-  <mesh filename="package://zed_msgs/meshes/${model}.stl" />
+  <mesh filename="$(find zed_msgs)/meshes/${model}.stl" />
             </geometry>
             <material name="${model}_mat" />
           </visual>
           <collision>
             <origin xyz="0 0 0" rpy="0 0 0"/>
             <geometry>
-  <mesh filename="package://zed_msgs/meshes/${model}.stl" />
+  <mesh filename="$(find zed_msgs)/meshes/${model}.stl" />
             </geometry>
           </collision>
         </xacro:if>
@@ -174,14 +174,14 @@
           <visual>
             <origin xyz="0 0 0" rpy="0 0 0"/>
             <geometry>
-  <mesh filename="package://zed_msgs/meshes/${model}.stl" />
+  <mesh filename="$(find zed_msgs)/meshes/${model}.stl" />
             </geometry>
             <material name="${model}_mat" />
           </visual>      
           <collision>
             <origin xyz="0 0 0" rpy="0 0 0"/>
             <geometry>
-  <mesh filename="package://zed_msgs/meshes/${model}.stl" />
+  <mesh filename="$(find zed_msgs)/meshes/${model}.stl" />
             </geometry>
           </collision>
         </xacro:if>

--- a/zed_wrapper/urdf/zed_macro.urdf.xacro
+++ b/zed_wrapper/urdf/zed_macro.urdf.xacro
@@ -118,14 +118,14 @@
         <visual>
           <origin xyz="${screw_offset_x} 0 ${screw_offset_z}" rpy="0 0 0"/>
           <geometry>
-<mesh filename="$(find zed_msgs)/meshes/${model}.stl" />
+<mesh filename="file://$(find zed_msgs)/meshes/${model}.stl"/>
           </geometry>
           <material name="${model}_mat" />
         </visual>      
         <collision>
           <origin xyz="${screw_offset_x} 0 ${screw_offset_z}" rpy="0 0 0"/>
           <geometry>
-<mesh filename="$(find zed_msgs)/meshes/${model}.stl" />
+<mesh filename="file://$(find zed_msgs)/meshes/${model}.stl"/>
           </geometry>
         </collision>
       </xacro:unless>
@@ -143,14 +143,14 @@
           <visual>
             <origin xyz="0 0 0" rpy="0 0 0"/>
             <geometry>
-  <mesh filename="$(find zed_msgs)/meshes/${model}.stl" />
+  <mesh filename="file://$(find zed_msgs)/meshes/${model}.stl"/>
             </geometry>
             <material name="${model}_mat" />
           </visual>
           <collision>
             <origin xyz="0 0 0" rpy="0 0 0"/>
             <geometry>
-  <mesh filename="$(find zed_msgs)/meshes/${model}.stl" />
+  <mesh filename="file://$(find zed_msgs)/meshes/${model}.stl"/>
             </geometry>
           </collision>
         </xacro:if>
@@ -174,14 +174,14 @@
           <visual>
             <origin xyz="0 0 0" rpy="0 0 0"/>
             <geometry>
-  <mesh filename="$(find zed_msgs)/meshes/${model}.stl" />
+  <mesh filename="file://$(find zed_msgs)/meshes/${model}.stl"/>
             </geometry>
             <material name="${model}_mat" />
           </visual>      
           <collision>
             <origin xyz="0 0 0" rpy="0 0 0"/>
             <geometry>
-  <mesh filename="$(find zed_msgs)/meshes/${model}.stl" />
+  <mesh filename="file://$(find zed_msgs)/meshes/${model}.stl"/>
             </geometry>
           </collision>
         </xacro:if>


### PR DESCRIPTION
After a recent update to the zed ros2 wrapper, I started experiencing an issue where Gazebo could not locate the zed stl meshes:

`[ruby $(which ign) gazebo-9] [Err] [SystemPaths.cc:378] Unable to find file with URI [model://zed_msgs/meshes/zed2i.stl]
[ruby $(which ign) gazebo-9] [Err] [SystemPaths.cc:473] Could not resolve file [model://zed_msgs/meshes/zed2i.stl]
[ruby $(which ign) gazebo-9] [Err] [MeshManager.cc:173] Unable to find file[model://zed_msgs/meshes/zed2i.stl]`

I realized that the issue is with how these files are being located inside of the zed_macro.urdf.xacro file, and the fix in this PR fixes the issue for me! If this PR could please be reviewed and merged that would be amazing! Thank you.