### PR TITLE
fix(zedxone): adjust resolutions checking

### DIFF
--- a/zed_components/src/zed_camera/src/zed_camera_one_component.cpp
+++ b/zed_components/src/zed_camera/src/zed_camera_one_component.cpp
@@ -273,14 +273,16 @@ void ZedCameraOne::getGeneralParams()
   getParam("general.grab_resolution", resol, resol);
   if (resol == "AUTO") {
     _camResol = sl::RESOLUTION::AUTO;
-  } else if (resol == "HD4K") {
+  } else if (resol == "HD4K" && _camUserModel == sl::MODEL::ZED_XONE_UHD) {
     _camResol = sl::RESOLUTION::HD4K;
-  } else if (resol == "QHDPLUS") {
+  } else if (resol == "QHDPLUS" && _camUserModel == sl::MODEL::ZED_XONE_UHD) {
     _camResol = sl::RESOLUTION::QHDPLUS;
   } else if (resol == "HD1200") {
     _camResol = sl::RESOLUTION::HD1200;
   } else if (resol == "HD1080") {
     _camResol = sl::RESOLUTION::HD1080;
+  } else if (resol == "SVGA") {
+    _camResol = sl::RESOLUTION::SVGA;
   } else {
     RCLCPP_WARN(
       get_logger(),


### PR DESCRIPTION
Add `SVGA` resoultion option to zedxone component.
Only allow `HD4K` and `QHDPLUS` for `ZED_XONE_UHD`