### PR TITLE
fix: add `cob_common` package to Dockerfile dependencies

### DIFF
--- a/docker/Dockerfile.l4t-humble
+++ b/docker/Dockerfile.l4t-humble
@@ -23,6 +23,7 @@ ARG ANGLES_VERSION=1.15.0
 ARG GEOGRAPHIC_INFO_VERSION=1.0.6
 ARG POINTCLOUD_TRANSPORT_VERSION=1.0.18
 ARG POINTCLOUD_TRANSPORT_PLUGINS_VERSION=1.0.11
+ARG COB_COMMON_VERSION=2.8.12
 
 
 ENV DEBIAN_FRONTEND=noninteractive
@@ -45,15 +46,15 @@ RUN apt-key adv --keyserver keyserver.ubuntu.com --recv-keys 42D5A192B819C5DA ||
 
 ENV TZ=Europe/Paris
 
-RUN ln -snf /usr/share/zoneinfo/$TZ /etc/localtime && echo $TZ > /etc/timezone && \ 
+RUN ln -snf /usr/share/zoneinfo/$TZ /etc/localtime && echo $TZ > /etc/timezone && \
   apt-get update && \
-  apt-get install --yes lsb-release wget less udev sudo build-essential cmake python3 python3-dev python3-pip python3-wheel git jq libpq-dev zstd usbutils && \    
+  apt-get install --yes lsb-release wget less udev sudo build-essential cmake python3 python3-dev python3-pip python3-wheel git jq libpq-dev zstd usbutils && \
   rm -rf /var/lib/apt/lists/*
 
 RUN echo "# R${L4T_MAJOR} (release), REVISION: ${L4T_MINOR}" > /etc/nv_tegra_release && \
   apt-get update -y || true && \
   apt-get install -y --no-install-recommends zstd wget less cmake curl gnupg2 \
-  build-essential python3 python3-pip python3-dev python3-setuptools libusb-1.0-0-dev \ 
+  build-essential python3 python3-pip python3-dev python3-setuptools libusb-1.0-0-dev \
   libgeographic-dev libdraco-dev zlib1g-dev -y && \
   pip install protobuf && \
   wget -q --no-check-certificate -O ZED_SDK_Linux_JP.run \
@@ -81,10 +82,11 @@ RUN wget https://github.com/ros/xacro/archive/refs/tags/${XACRO_VERSION}.tar.gz 
     wget https://github.com/ros/angles/archive/refs/tags/${ANGLES_VERSION}.tar.gz -O - | tar -xvz && mv angles-${ANGLES_VERSION} angles && \
     wget https://github.com/ros-perception/point_cloud_transport/archive/refs/tags/${POINTCLOUD_TRANSPORT_VERSION}.tar.gz -O - | tar -xvz && mv point_cloud_transport-${POINTCLOUD_TRANSPORT_VERSION} point_cloud_transport && \
     wget https://github.com/ros-perception/point_cloud_transport_plugins/archive/refs/tags/${POINTCLOUD_TRANSPORT_PLUGINS_VERSION}.tar.gz -O - | tar -xvz && mv point_cloud_transport_plugins-${POINTCLOUD_TRANSPORT_PLUGINS_VERSION} point_cloud_transport_plugins && \
+    wget https://github.com/4am-robotics/cob_common/archive/refs/tags/${COB_COMMON_VERSION}.tar.gz -O - | tar -xvz && mv cob_common-${COB_COMMON_VERSION} cob_common && \
     wget https://github.com/ros-geographic-info/geographic_info/archive/refs/tags/${GEOGRAPHIC_INFO_VERSION}.tar.gz -O - | tar -xvz && mv geographic_info-${GEOGRAPHIC_INFO_VERSION} geographic-info && \
     cp -r geographic-info/geographic_msgs/ . && \
     rm -rf geographic-info
-    
+
 # Install cython
 RUN python3 -m pip install --upgrade cython
 
@@ -100,7 +102,7 @@ RUN /bin/bash -c "source /opt/ros/$ROS_DISTRO/install/setup.bash && \
 
 WORKDIR /root/ros2_ws
 
-# Setup environment variables 
+# Setup environment variables
 COPY ros_entrypoint_jetson.sh /sbin/ros_entrypoint.sh
 RUN sudo chmod 755 /sbin/ros_entrypoint.sh
 


### PR DESCRIPTION
When trying to build the Jetson Dockefile with `` the colcon build command fails as the workspace does not have `cob_srvs` package.

<details><summary>Details</summary>
<p>

> 294.2 Starting >>> zed_components
294.5 CMake Deprecation Warning at CMakeLists.txt:1 (cmake_minimum_required):
294.5   Compatibility with CMake < 3.10 will be removed from a future version of
294.5   CMake.
294.5 
294.5   Update the VERSION argument <min> value or use a ...<max> suffix to tell
294.5   CMake that the project does not need compatibility with older versions.
294.5 
294.5 
294.5 Not searching for unused variables given on the command line.
294.5 -- The C compiler identification is GNU 11.4.0
294.6 -- The CXX compiler identification is GNU 11.4.0
294.6 -- Detecting C compiler ABI info
294.7 -- Detecting C compiler ABI info - done
294.7 -- Check for working C compiler: /usr/bin/cc - skipped
294.7 -- Detecting C compile features
294.7 -- Detecting C compile features - done
294.8 -- Detecting CXX compiler ABI info
294.9 -- Detecting CXX compiler ABI info - done
294.9 -- Check for working CXX compiler: /usr/bin/c++ - skipped
294.9 -- Detecting CXX compile features
294.9 -- Detecting CXX compile features - done
294.9 -- Looking for sgemm_
295.0 -- Looking for sgemm_ - not found
295.0 -- Performing Test CMAKE_HAVE_LIBC_PTHREAD
295.1 -- Performing Test CMAKE_HAVE_LIBC_PTHREAD - Success
295.1 -- Found Threads: TRUE
295.2 -- Looking for sgemm_
295.3 -- Looking for sgemm_ - found
295.3 -- Found BLAS: /usr/lib/aarch64-linux-gnu/libopenblas.so
295.3 CMake Warning (dev) at /usr/local/zed/zed-config.cmake:72 (find_package):
295.3   Policy CMP0146 is not set: The FindCUDA module is removed.  Run "cmake
295.3   --help-policy CMP0146" for policy details.  Use the cmake_policy command to
295.3   set the policy and suppress this warning.
295.3 
295.3 Call Stack (most recent call first):
295.3   CMakeLists.txt:84 (find_package)
295.3 This warning is for project developers.  Use -Wno-dev to suppress it.
295.3 
295.4 -- Found CUDA: /usr/local/cuda (found suitable version "12.2", minimum required is "12.2")
295.4 CMake Warning (dev) at /usr/local/zed/zed-config.cmake:77 (exec_program):
295.4   Policy CMP0153 is not set: The exec_program command should not be called.
295.4   Run "cmake --help-policy CMP0153" for policy details.  Use the cmake_policy
295.4   command to set the policy and suppress this warning.
295.4 
295.4   Use execute_process() instead.
295.4 Call Stack (most recent call first):
295.4   CMakeLists.txt:84 (find_package)
295.4 This warning is for project developers.  Use -Wno-dev to suppress it.
295.4 
295.4 CMake Warning (dev) at /usr/local/zed/zed-config.cmake:78 (exec_program):
295.4   Policy CMP0153 is not set: The exec_program command should not be called.
295.4   Run "cmake --help-policy CMP0153" for policy details.  Use the cmake_policy
295.4   command to set the policy and suppress this warning.
295.4 
295.4   Use execute_process() instead.
295.4 Call Stack (most recent call first):
295.4   CMakeLists.txt:84 (find_package)
295.4 This warning is for project developers.  Use -Wno-dev to suppress it.
295.4 
295.4 CMake Warning (dev) at /usr/local/zed/zed-config.cmake:94 (exec_program):
295.4   Policy CMP0153 is not set: The exec_program command should not be called.
295.4   Run "cmake --help-policy CMP0153" for policy details.  Use the cmake_policy
295.4   command to set the policy and suppress this warning.
295.4 
295.4   Use execute_process() instead.
295.4 Call Stack (most recent call first):
295.4   CMakeLists.txt:84 (find_package)
295.4 This warning is for project developers.  Use -Wno-dev to suppress it.
295.4 
295.4 CMake Warning (dev) at /usr/local/zed/zed-config.cmake:122 (exec_program):
295.4   Policy CMP0153 is not set: The exec_program command should not be called.
295.4   Run "cmake --help-policy CMP0153" for policy details.  Use the cmake_policy
295.4   command to set the policy and suppress this warning.
295.4 
295.4   Use execute_process() instead.
295.4 Call Stack (most recent call first):
295.4   CMakeLists.txt:84 (find_package)
295.4 This warning is for project developers.  Use -Wno-dev to suppress it.
295.4 
295.4 CMake Warning (dev) at CMakeLists.txt:86 (exec_program):
295.4   Policy CMP0153 is not set: The exec_program command should not be called.
295.4   Run "cmake --help-policy CMP0153" for policy details.  Use the cmake_policy
295.4   command to set the policy and suppress this warning.
295.4 
295.4   Use execute_process() instead.
295.4 This warning is for project developers.  Use -Wno-dev to suppress it.
295.4 
295.4 CMake Warning (dev) at CMakeLists.txt:91 (find_package):
295.4   Policy CMP0146 is not set: The FindCUDA module is removed.  Run "cmake
295.4   --help-policy CMP0146" for policy details.  Use the cmake_policy command to
295.4   set the policy and suppress this warning.
295.4 
295.4 This warning is for project developers.  Use -Wno-dev to suppress it.
295.4 
295.4 -- Found CUDA: /usr/local/cuda (found version "12.2")
295.4 -- Found ament_cmake_auto: 1.3.10 (/opt/ros/humble/install/share/ament_cmake_auto/cmake)
295.6 -- Found Python3: /usr/local/bin/python3 (found version "3.10.12") found components: Interpreter
295.8 -- Override CMake install command with custom implementation using symlinks instead of copying resources
296.0 -- Found rosidl_generator_c: 3.1.5 (/opt/ros/humble/install/share/rosidl_generator_c/cmake)
296.1 -- Found rosidl_adapter: 3.1.5 (/opt/ros/humble/install/share/rosidl_adapter/cmake)
296.1 -- Found rosidl_generator_cpp: 3.1.5 (/opt/ros/humble/install/share/rosidl_generator_cpp/cmake)
296.1 -- Using all available rosidl_typesupport_c: rosidl_typesupport_fastrtps_c;rosidl_typesupport_introspection_c
296.1 -- Using all available rosidl_typesupport_cpp: rosidl_typesupport_fastrtps_cpp;rosidl_typesupport_introspection_cpp
296.4 -- Found rmw_implementation_cmake: 6.1.2 (/opt/ros/humble/install/share/rmw_implementation_cmake/cmake)
296.4 -- Found rmw_fastrtps_cpp: 6.2.7 (/opt/ros/humble/install/share/rmw_fastrtps_cpp/cmake)
296.6 -- Found OpenSSL: /usr/lib/aarch64-linux-gnu/libcrypto.so (found version "3.0.2")
296.6 -- Found FastRTPS: /opt/ros/humble/install/include
296.7 -- Using RMW implementation 'rmw_fastrtps_cpp' as default
297.3 -- Found eigen3_cmake_module: 0.1.1 (/opt/ros/humble/install/share/eigen3_cmake_module/cmake)
297.3 -- Found Eigen3: TRUE (found version "3.4.0")
297.3 -- Ensuring Eigen3 include directory is part of orocos-kdl CMake target
297.5 CMake Error at CMakeLists.txt:139 (find_package):
297.5   By not providing "Findcob_srvs.cmake" in CMAKE_MODULE_PATH this project has
297.5   asked CMake to find a package configuration file provided by "cob_srvs",
297.5   but CMake did not find one.
297.5 
297.5   Could not find a package configuration file provided by "cob_srvs" with any
297.5   of the following names:
297.5 
297.5     cob_srvsConfig.cmake
297.5 -- Configuring incomplete, errors occurred!
297.5     cob_srvs-config.cmake
297.5 
297.5   Add the installation prefix of "cob_srvs" to CMAKE_PREFIX_PATH or set
297.5   "cob_srvs_DIR" to a directory containing one of the above files.  If
297.5   "cob_srvs" provides a separate development package or SDK, be sure it has
297.5   been installed.

</p>
</details> 

This PR add `cobs_common` on its latest version `2.8.12`