### PR TITLE
docker: add Cyclone DDS middleware & tuning support

### DIFF
--- a/docker/Dockerfile.desktop-humble
+++ b/docker/Dockerfile.desktop-humble
@@ -74,6 +74,7 @@ RUN apt-get update || true && \
 RUN apt-get update || true && \
   apt-get install --no-install-recommends -y \
   ros-${ROS2_DIST}-ros-base \
+  ros-${ROS2_DIST}-rmw-cyclonedds-cpp \
   python3-flake8-docstrings \
   python3-pip \
   python3-pytest-cov \
@@ -84,6 +85,13 @@ RUN apt-get update || true && \
   empy \
   lark && \
   rm -rf /var/lib/apt/lists/*
+
+ # Default DDS middleware
+ ENV RMW_IMPLEMENTATION=rmw_cyclonedds_cpp
+ 
+ # Copy Cyclone DDS tuning file
+ COPY cyclonedds.xml /root/cyclonedds.xml
+ ENV CYCLONEDDS_URI=file:///root/cyclonedds.xml
 
 # Initialize rosdep
 RUN rosdep init && rosdep update

--- a/docker/cyclonedds.xml
+++ b/docker/cyclonedds.xml
@@ -1,0 +1,16 @@
+<?xml version="1.0" encoding="UTF-8" ?>
+<CycloneDDS xmlns="https://cdds.io/config"
+            xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+            xsi:schemaLocation="https://cdds.io/config https://raw.githubusercontent.com/eclipse-cyclonedds/cyclonedds/master/etc/cyclonedds.xsd">
+  <Domain Id="any">
+    <General>
+      <MaxMessageSize>65500B</MaxMessageSize>
+    </General>
+    <Internal>
+      <SocketReceiveBufferSize min="10MB"/>
+      <Watermarks>
+        <WhcHigh>500kB</WhcHigh>
+      </Watermarks>
+    </Internal>
+  </Domain>
+</CycloneDDS>


### PR DESCRIPTION
Installs ros-${ROS2_DIST}-rmw-cyclonedds-cpp and sets RMW_IMPLEMENTATION=rmw_cyclonedds_cpp by default to switch from Fast DDS to Cyclone DDS -- Copies a cyclonedds.xml into the image and sets CYCLONEDDS_URI to enable tuned parameters  for reliable large‑message streaming