### PR TITLE
Fix graceful exit of ZED component node

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -1,6 +1,10 @@
 LATEST CHANGES
 ==============
 
+2025-04-23
+----------
+- Clean shutdown of ZED components using `pre_shutdown_callback`
+
 2025-04-22
 ----------
 - Add backward compatibility with SDK v4.2

--- a/zed_components/src/zed_camera/include/zed_camera_component.hpp
+++ b/zed_components/src/zed_camera/include/zed_camera_component.hpp
@@ -81,7 +81,7 @@ protected:
   void stopSvoRecording();
   bool startStreamingServer();
   void stopStreamingServer();
-  bool closeCamera();
+  void closeCamera();
   // <---- Initialization functions
 
   // ----> Callbacks

--- a/zed_components/src/zed_camera/include/zed_camera_component.hpp
+++ b/zed_components/src/zed_camera/include/zed_camera_component.hpp
@@ -42,6 +42,8 @@ protected:
   void initServices();
   void initThreads();
 
+  void close();
+
   void getDebugParams();
   void getSimParams();
   void getGeneralParams();
@@ -79,6 +81,7 @@ protected:
   void stopSvoRecording();
   bool startStreamingServer();
   void stopStreamingServer();
+  bool closeCamera();
   // <---- Initialization functions
 
   // ----> Callbacks

--- a/zed_components/src/zed_camera/include/zed_camera_one_component.hpp
+++ b/zed_components/src/zed_camera/include/zed_camera_one_component.hpp
@@ -54,7 +54,10 @@ protected:
   void getStreamingServerParams();
   void getAdvancedParams();
 
+  void close();
+
   bool startCamera();
+  void closeCamera();
   void startTempPubTimer();
   bool startStreamingServer();
   void stopStreamingServer();

--- a/zed_components/src/zed_camera/src/zed_camera_component.cpp
+++ b/zed_components/src/zed_camera/src/zed_camera_component.cpp
@@ -187,7 +187,8 @@ void ZedCamera::init()
     std::bind(&ZedCamera::callback_setParameters, this, _1));
 }
 
-void ZedCamera::close() {
+void ZedCamera::close()
+{
 
   // ----> Stop subscribers
   mClickedPtSub.reset();
@@ -4433,7 +4434,7 @@ bool ZedCamera::startCamera()
   // <---- Set Region of Interest
 
   // ----> Check default camera settings
-  if (_debugCamCtrl) {
+  if (_debugCamCtrl && !mSvoMode) {
     int value;
     sl::ERROR_CODE err;
     sl::VIDEO_SETTINGS setting;
@@ -4890,8 +4891,9 @@ bool ZedCamera::startCamera()
 bool ZedCamera::closeCamera()
 {
   RCLCPP_INFO(get_logger(), "***** CLOSING CAMERA *****");
-  if (mZed == nullptr)
+  if (mZed == nullptr) {
     return true;
+  }
 
   mZed->close();
   mZed.reset();
@@ -4899,6 +4901,7 @@ bool ZedCamera::closeCamera()
 
   return true;
 }
+
 void ZedCamera::initThreads()
 {
   // ----> Start CMOS Temperatures thread

--- a/zed_components/src/zed_camera/src/zed_camera_component.cpp
+++ b/zed_components/src/zed_camera/src/zed_camera_component.cpp
@@ -177,9 +177,9 @@ void ZedCamera::init()
   using rclcpp::contexts::get_global_default_context;
   get_global_default_context()->add_pre_shutdown_callback(
     [this]() {
-      DEBUG_STREAM_COMM("ZED node is shutting down");
+      DEBUG_COMM("ZED Component is shutting down");
       close();
-      DEBUG_STREAM_COMM("ZED node is shutting down - done");
+      DEBUG_COMM("ZED Component is shutting down - done");
     });
 
   // Dynamic parameters callback
@@ -261,11 +261,7 @@ void ZedCamera::close()
   }
   DEBUG_STREAM_PC("... Point Cloud thread stopped");
 
-  if (closeCamera()) {
-    DEBUG_STREAM_COMM("Camera closed");
-  } else {
-    DEBUG_STREAM_COMM("Error while closing camera");
-  }
+  closeCamera();
 }
 
 ZedCamera::~ZedCamera()
@@ -4888,18 +4884,17 @@ bool ZedCamera::startCamera()
   return true;
 }  // namespace stereolabs
 
-bool ZedCamera::closeCamera()
-{
-  RCLCPP_INFO(get_logger(), "***** CLOSING CAMERA *****");
+void ZedCamera::closeCamera()
+{  
   if (mZed == nullptr) {
-    return true;
+    return;
   }
+
+  RCLCPP_INFO(get_logger(), "***** CLOSING CAMERA *****");
 
   mZed->close();
   mZed.reset();
   DEBUG_COMM("Camera closed");
-
-  return true;
 }
 
 void ZedCamera::initThreads()


### PR DESCRIPTION
Call the explicit close() of the sl::Camera in a `pre_shutdown_callback`, as the destructor of ZedCamera seems to never be called in ROS2 humble

This was especially critical for ZED X which requires a graceful shutdown to avoid nvargus crashes.

To test, use the following config:
```
        debug:
            sdk_verbose: 1 # Set the verbose level of the ZED SDK
            sdk_verbose_log_file: '' # Path to the file where the ZED SDK will log its messages. If empty, no file will be created. The log level can be set using the `sdk_verbose` parameter.
            debug_common: true
            debug_sim: false
            debug_video_depth: false
            debug_camera_controls: false
            debug_point_cloud: true
            debug_positional_tracking: false
            debug_gnss: false
            debug_sensors: true
```

And check if the grab, sensor and point cloud elab threads are correctly closed