### PR TITLE
Fix L4T R35.4.1 Humble Docker build

### DIFF
--- a/docker/Dockerfile.l4t-humble
+++ b/docker/Dockerfile.l4t-humble
@@ -64,7 +64,7 @@ RUN echo "# R${L4T_MAJOR} (release), REVISION: ${L4T_MINOR}" > /etc/nv_tegra_rel
   pip install protobuf && \
   wget -q --no-check-certificate -O ZED_SDK_Linux_JP.run \
   ${ZED_SDK_URL} && \
-  chmod +x ZED_SDK_Linux_JP.run ; ./ZED_SDK_Linux_JP.run silent skip_tools && \
+  chmod +x ZED_SDK_Linux_JP.run ; ./ZED_SDK_Linux_JP.run silent && \
   rm -rf /usr/local/zed/resources/* && \
   rm -rf ZED_SDK_Linux_JP.run && \
   rm -rf /var/lib/apt/lists/*

--- a/docker/Dockerfile.l4t-humble
+++ b/docker/Dockerfile.l4t-humble
@@ -17,6 +17,7 @@ ARG ROS2_DIST=humble
 
 # ZED ROS2 Wrapper dependencies version
 ARG XACRO_VERSION=2.0.8
+ARG DRACO_VERSION=1.5.7
 ARG DIAGNOSTICS_VERSION=4.0.0
 ARG AMENT_LINT_VERSION=0.12.11
 ARG ROBOT_LOCALIZATION_VERSION=3.5.3
@@ -24,6 +25,7 @@ ARG ZED_MSGS_VERSION=5.0.0
 ARG NMEA_MSGS_VERSION=2.0.0
 ARG ANGLES_VERSION=1.15.0
 ARG GEOGRAPHIC_INFO_VERSION=1.0.6
+ARG RCPPUTILS_VERSION=2.11.2
 ARG POINTCLOUD_TRANSPORT_VERSION=1.0.18
 ARG POINTCLOUD_TRANSPORT_PLUGINS_VERSION=1.0.11
 ARG RMW_CYCLONEDDS_VERSION=1.3.4
@@ -58,7 +60,7 @@ RUN echo "# R${L4T_MAJOR} (release), REVISION: ${L4T_MINOR}" > /etc/nv_tegra_rel
   apt-get update -y || true && \
   apt-get install -y --no-install-recommends zstd wget less cmake curl gnupg2 \
   build-essential python3 python3-pip python3-dev python3-setuptools libusb-1.0-0-dev \ 
-  libgeographic-dev libdraco-dev zlib1g-dev -y && \
+  libgeographic-dev zlib1g-dev -y && \
   pip install protobuf && \
   wget -q --no-check-certificate -O ZED_SDK_Linux_JP.run \
   ${ZED_SDK_URL} && \
@@ -77,12 +79,14 @@ COPY tmp_sources/ ./
 # Install missing dependencies from the sources
 WORKDIR /root/ros2_ws/src
 RUN wget https://github.com/ros/xacro/archive/refs/tags/${XACRO_VERSION}.tar.gz -O - | tar -xvz && mv xacro-${XACRO_VERSION} xacro && \
+    wget https://github.com/google/draco/archive/refs/tags/${DRACO_VERSION}.tar.gz -O - | tar -xvz && mv draco-${DRACO_VERSION} draco && cd draco && mkdir -p build && cd build && cmake .. && make install && cd ../.. && \
     wget https://github.com/ros/diagnostics/archive/refs/tags/${DIAGNOSTICS_VERSION}.tar.gz -O - | tar -xvz && mv diagnostics-${DIAGNOSTICS_VERSION} diagnostics && \
     wget https://github.com/ament/ament_lint/archive/refs/tags/${AMENT_LINT_VERSION}.tar.gz -O - | tar -xvz && mv ament_lint-${AMENT_LINT_VERSION} ament-lint && \
     wget https://github.com/cra-ros-pkg/robot_localization/archive/refs/tags/${ROBOT_LOCALIZATION_VERSION}.tar.gz -O - | tar -xvz && mv robot_localization-${ROBOT_LOCALIZATION_VERSION} robot-localization && \
     wget https://github.com/stereolabs/zed-ros2-interfaces/archive/refs/tags/${ZED_MSGS_VERSION}.tar.gz -O - | tar -xvz && mv zed-ros2-interfaces-${ZED_MSGS_VERSION} zed-ros2-interfaces && \
     wget https://github.com/ros-drivers/nmea_msgs/archive/refs/tags/${NMEA_MSGS_VERSION}.tar.gz -O - | tar -xvz && mv nmea_msgs-${NMEA_MSGS_VERSION} nmea_msgs && \
     wget https://github.com/ros/angles/archive/refs/tags/${ANGLES_VERSION}.tar.gz -O - | tar -xvz && mv angles-${ANGLES_VERSION} angles && \
+    wget https://github.com/ros2/rcpputils/archive/refs/tags/${RCPPUTILS_VERSION}.tar.gz -O - | tar -xvz && mv rcpputils-${RCPPUTILS_VERSION} rcpputils && \
     wget https://github.com/ros-perception/point_cloud_transport/archive/refs/tags/${POINTCLOUD_TRANSPORT_VERSION}.tar.gz -O - | tar -xvz && mv point_cloud_transport-${POINTCLOUD_TRANSPORT_VERSION} point_cloud_transport && \
     wget https://github.com/ros-perception/point_cloud_transport_plugins/archive/refs/tags/${POINTCLOUD_TRANSPORT_PLUGINS_VERSION}.tar.gz -O - | tar -xvz && mv point_cloud_transport_plugins-${POINTCLOUD_TRANSPORT_PLUGINS_VERSION} point_cloud_transport_plugins && \
     wget https://github.com/ros2/rmw_cyclonedds/archive/refs/tags/${RMW_CYCLONEDDS_VERSION}.tar.gz -O - | tar -xvz && mv rmw_cyclonedds-${RMW_CYCLONEDDS_VERSION} rmw_cyclonedds && \


### PR DESCRIPTION
I had the exact same issue as described in #314 (and then some other issues) so I made some adjustments to the Dockerfile in that regard: building Draco from source, as well as RcppUtils.
I also reintroduced the ZED tools in the docker. I can understand why you wouldn't want to include them in a docker dedicated to ROS2 usage of the cameras, but there are installed anyway, just missing a few Qt5 dependencies, so I figured it was better to install these dependencies and make the tools usable. Let me know if you want me to remove the corresponding commit.

I haven't tested Jetson Humble docker build on other L4T versions than R35.4.1, but I tested with ZED SDK 4.2.3 and 5.0.0 with success.

Best regards