### PR TITLE
Fix update diagnostic segfault on camera close

### DIFF
--- a/zed_components/src/zed_camera/include/zed_camera_component.hpp
+++ b/zed_components/src/zed_camera/include/zed_camera_component.hpp
@@ -739,6 +739,7 @@ private:
   std::mutex mObjDetMutex;
   std::mutex mBodyTrkMutex;
   std::mutex mPcMutex;
+  std::mutex mCloseCameraMutex;
   std::condition_variable mPcDataReadyCondVar;
   std::atomic_bool mPcDataReady;
   // <---- Thread Sync

--- a/zed_components/src/zed_camera/src/zed_camera_component_main.cpp
+++ b/zed_components/src/zed_camera/src/zed_camera_component_main.cpp
@@ -4191,6 +4191,7 @@ bool ZedCamera::startCamera()
 
 void ZedCamera::closeCamera()
 {
+  std::lock_guard<std::mutex> lock(mCloseCameraMutex);
   if (mZed == nullptr) {
     return;
   }
@@ -9237,6 +9238,15 @@ void ZedCamera::callback_updateDiagnostic(
   diagnostic_updater::DiagnosticStatusWrapper & stat)
 {
   DEBUG_COMM("=== Update Diagnostic ===");
+
+  std::lock_guard<std::mutex> lock(mCloseCameraMutex);
+
+  if (mZed == nullptr) {
+    stat.summary(
+      diagnostic_msgs::msg::DiagnosticStatus::ERROR,
+      "Camera not opened");
+    return;
+  }
 
   if (mConnStatus != sl::ERROR_CODE::SUCCESS) {
     stat.summary(


### PR DESCRIPTION
Fixes issue when closing camera with new close mechanism, which would create race condition in update diagnostic callback, not checking the validity of the mZed pointer.