### PR TITLE
Put back in publish_svo_clock missing code

### DIFF
--- a/zed_components/src/zed_camera/src/zed_camera_component_main.cpp
+++ b/zed_components/src/zed_camera/src/zed_camera_component_main.cpp
@@ -715,6 +715,12 @@ void ZedCamera::getGeneralParams()
       shared_from_this(), "svo.use_svo_timestamps",
       mUseSvoTimestamp, mUseSvoTimestamp,
       " * Use SVO timestamp: ");
+		if (mUseSvoTimestamp) {
+			sl_tools::getParam(
+				shared_from_this(), "svo.publish_svo_clock",
+				mPublishSvoClock, mPublishSvoClock,
+				" * Publish SVO timestamp: ");
+    }
 
     sl_tools::getParam(shared_from_this(), "svo.svo_loop", mSvoLoop, mSvoLoop);
     if (mUseSvoTimestamp) {


### PR DESCRIPTION
Put back in a chunk of code from this [commit](https://github.com/stereolabs/zed-ros2-wrapper/commit/9a9dc3e60d1537ebaa689a19b562c54f10458433#diff-6b1e40243c6ad2b72c35d3eaf286ecbf7cd56574b9fffc2a253285c740a600fa) that seems to have been lost throughout some merges but is needed to keep `publish_svo_clock` working. 