### PR TITLE
Add reboot service

### DIFF
--- a/zed_components/src/tools/include/sl_types.hpp
+++ b/zed_components/src/tools/include/sl_types.hpp
@@ -157,6 +157,7 @@ typedef std::shared_ptr<rclcpp::Subscription<geometry_msgs::msg::PointStamped>> 
 typedef std::shared_ptr<rclcpp::Subscription<sensor_msgs::msg::NavSatFix>> gnssFixSub;
 typedef std::shared_ptr<rclcpp::Subscription<rosgraph_msgs::msg::Clock>> clockSub;
 
+typedef rclcpp::Service<std_srvs::srv::Trigger>::SharedPtr rebootSrvPtr;
 typedef rclcpp::Service<std_srvs::srv::Trigger>::SharedPtr resetOdomSrvPtr;
 typedef rclcpp::Service<std_srvs::srv::Trigger>::SharedPtr resetPosTrkSrvPtr;
 typedef rclcpp::Service<zed_msgs::srv::SetPose>::SharedPtr setPoseSrvPtr;

--- a/zed_components/src/zed_camera/include/zed_camera_component.hpp
+++ b/zed_components/src/zed_camera/include/zed_camera_component.hpp
@@ -217,6 +217,8 @@ protected:
   void handlePointCloudPublishing();
   // Sensors thread
   void threadFunc_pubSensorsData();
+  // Restart thread
+  void threadFunc_zedRestart();
   // <---- Thread functions
 
   // ----> Publishing functions
@@ -810,6 +812,7 @@ private:
   std::thread mVdThread;          // Video and Depth data processing thread
   std::thread mPcThread;          // Point Cloud publish thread
   std::thread mSensThread;        // Sensors data publish thread
+  std::thread mRestartThread;     // Camera restart thread for reboot service
   std::atomic<bool> mThreadStop;
   rclcpp::TimerBase::SharedPtr mInitTimer;
   rclcpp::TimerBase::SharedPtr mPathTimer;
@@ -834,7 +837,6 @@ private:
   std::mutex mVdMutex;
   std::condition_variable mVdDataReadyCondVar;
   std::atomic_bool mVdDataReady;
-  bool mCameraClosed = false;  // Indicates if the camera has been closed
   bool mCameraRebooting = false; // Indicates if the camera is being rebooted
   int activeUsers = 0;
   std::mutex mRebootMutex;  // Mutex to protect camera rebooting

--- a/zed_components/src/zed_camera/include/zed_camera_component.hpp
+++ b/zed_components/src/zed_camera/include/zed_camera_component.hpp
@@ -85,6 +85,7 @@ protected:
   bool startStreamingServer();
   void stopStreamingServer();
   void closeCamera();
+  bool restartCamera();
   // <---- Initialization functions
 
   // ----> Dynamic Parameters Handlers
@@ -833,10 +834,11 @@ private:
   std::mutex mVdMutex;
   std::condition_variable mVdDataReadyCondVar;
   std::atomic_bool mVdDataReady;
-  bool mCameraRebooting = false;
+  bool mCameraClosed = false;  // Indicates if the camera has been closed
+  bool mCameraRebooting = false; // Indicates if the camera is being rebooted
   int activeUsers = 0;
   std::mutex mRebootMutex;  // Mutex to protect camera rebooting
-  std::condition_variable mRebootCondVar;  // Condition variable to wait for camera
+  std::condition_variable mRebootCondVar;  // Condition variable to wait for camera during reboot process
   // <---- Thread Sync
 
   // ----> Status Flags


### PR DESCRIPTION
Add /reboot service to restart camera on failure. Support USB and GMSL.
Please note that GMSL reboot impacts all connected cameras.