### PR TITLE
Fix bug where ZED X One crashes after 1 frame

### DIFF
--- a/zed_components/src/zed_camera/src/zed_camera_one_component.cpp
+++ b/zed_components/src/zed_camera/src/zed_camera_one_component.cpp
@@ -2888,10 +2888,14 @@ void ZedCameraOne::publishImageWithInfo(
   const rclcpp::Time & t)
 {
   auto image = sl_tools::imageToROSmsg(img, imgFrameId, t, false);
-  camInfoMsg->header.stamp = t;
+  if (camInfoMsg) {
+    camInfoMsg->header.stamp = t;
+  } else {
+    DEBUG_STREAM_COMM("Camera info message is not valid");
+  }
   DEBUG_STREAM_VD("Publishing IMAGE message: " << t.nanoseconds() << " nsec");
   try {
-    pubImg.publish(std::move(image), std::move(camInfoMsg));
+    pubImg.publish(std::move(image), camInfoMsg);
   } catch (std::system_error & e) {
     DEBUG_STREAM_COMM("Message publishing ecception: " << e.what());
   } catch (...) {


### PR DESCRIPTION
When connecting a Zed X One GS camera, the ROS2 wrapper publishes a single frame or single camera info and then dies. This appears to be related to the ROS wrapper, as the ZED_Explorer and other sensor data (such as the IMU and temperature) work as expected. Test case that lead to this issue:
- ROS 2 Jazzy (both default RMW and Zenoh RMW), containerized using Docker with appropriate permissions/mounts.
- ZED Mini Carrier Board with a NVIDIA Orin NX 16GB, 512GB SSD storage.
- Two ZED X One GS cameras connected using 15cm GMSL cables.

 Attaching GDB to the process lead to the following traceback:
```
Thread 2 "component_conta" received signal SIGSEGV, Segmentation fault.
[Switching to Thread 0xfffeeb9ae040 (LWP 2466)]
0x0000ffff841e7d18 in stereolabs::ZedCameraOne::publishImageWithInfo (this=this@entry=0xaaaabf95fdb0, img=..., pubImg=..., camInfoMsg=std::shared_ptr<sensor_msgs::msg::CameraInfo_<std::allocator<void> >> (empty) = {...}, imgFrameId="zed_one_camera_optical_frame", t=...)
    at /workspaces/XXX/workspace/zed-ros2-wrapper/zed_components/src/zed_camera/src/zed_camera_one_component.cpp:2895
2895	  camInfoMsg->header.stamp = t;
(gdb) bt
#0  0x0000ffff841e7d18 in stereolabs::ZedCameraOne::publishImageWithInfo (this=this@entry=0xaaaabf95fdb0, img=..., pubImg=..., camInfoMsg=std::shared_ptr<sensor_msgs::msg::CameraInfo_<std::allocator<void> >> (empty) = {...}, imgFrameId="zed_one_camera_optical_frame", t=...)
    at /workspaces/XXX/workspace/zed-ros2-wrapper/zed_components/src/zed_camera/src/zed_camera_one_component.cpp:2895
#1  0x0000ffff8420af08 in stereolabs::ZedCameraOne::publishImages (this=this@entry=0xaaaabf95fdb0) at /workspaces/XXX/workspace/zed-ros2-wrapper/zed_components/src/zed_camera/src/zed_camera_one_component.cpp:2841
#2  0x0000ffff8420d2a4 in stereolabs::ZedCameraOne::threadFunc_zedGrab (this=0xaaaabf95fdb0) at /workspaces/XXX/workspace/zed-ros2-wrapper/zed_components/src/zed_camera/src/zed_camera_one_component.cpp:1927
#3  0x0000ffff8d781ae0 in ?? () from /usr/lib/aarch64-linux-gnu/libstdc++.so.6
#4  0x0000ffff8d52595c [PAC] in start_thread (arg=0xffff8dc42760) at ./nptl/pthread_create.c:447
#5  0x0000ffff8d58ba4c in thread_start () at ../sysdeps/unix/sysv/linux/aarch64/clone3.S:76
```

From this, it appears that the cameraInfoMsg pointer (which is re-used for all frames) goes out-of-scope and becomes invalid.

This PR introduces an additional NULL check on `camInfoMsg` and removes the `std::move` on the camInfoMsg. Other solutions to this problem (e.g. creating a new camInfoMsg every iteration so it can be `std::move`d) are also possible, so feel free to close/amend this PR in favor of another solution. 

After making the changes above, I am able to run the ROS2 wrapper without it crashing after the first frame.