### PR TITLE
docs(readme): fix broken colcon tutorial link (index.ros.org 404)

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,7 +41,7 @@ This package enables the use of ZED cameras with ROS 2, providing access to a va
 
 The **zed_ros2_wrapper** is a [colcon](http://design.ros2.org/articles/build_tool.html) package.
 
-> :pushpin: **Note:** If you haven’t set up your colcon workspace yet, please follow this short [tutorial](https://index.ros.org/doc/ros2/Tutorials/Colcon-Tutorial/).
+> :pushpin: **Note:** If you haven’t set up your colcon workspace yet, please follow this short [tutorial](https://docs.ros.org/en/humble/Tutorials/Beginner-Client-Libraries/Colcon-Tutorial.html).
 
 To install the **zed_ros2_wrapper**, open a bash terminal, clone the package from GitHub, and build it:
 


### PR DESCRIPTION
## Summary

The README's *Build the package* section points to the old `index.ros.org` URL for the colcon tutorial:

Before:
```
https://index.ros.org/doc/ros2/Tutorials/Colcon-Tutorial/
```

That URL currently returns 404 (the `index.ros.org/doc/ros2/...` tree was retired in favor of `docs.ros.org/en/<distro>/...`). Replaced with the canonical Humble tutorial, consistent with the Humble/Jazzy links already used elsewhere in the README:
```
https://docs.ros.org/en/humble/Tutorials/Beginner-Client-Libraries/Colcon-Tutorial.html
```

Closes #424

## Testing

Documentation-only change. Verified the new URL renders the Colcon tutorial on the ROS 2 Humble docs site.