### PR TITLE
Fix Custom Object Detection pipeline (CUSTOM_YOLOLIKE_BOX_OBJECTS)

### DIFF
--- a/zed_components/src/zed_camera/src/zed_camera_component_objdet.cpp
+++ b/zed_components/src/zed_camera/src/zed_camera_component_objdet.cpp
@@ -1086,17 +1086,31 @@ void ZedCamera::processDetectedObjects(rclcpp::Time t)
       mZed->setObjectDetectionRuntimeParameters(objectTracker_parameters_rt);
     }
 #if (ZED_SDK_MAJOR_VERSION * 10 + ZED_SDK_MINOR_VERSION) >= 50
-    else {
-      sl::CustomObjectDetectionRuntimeParameters custom_objectTracker_parameters_rt;
-      custom_objectTracker_parameters_rt.object_class_detection_properties = mCustomOdProperties;
-      mZed->setCustomObjectDetectionRuntimeParameters(custom_objectTracker_parameters_rt);
-    }
+    // Custom OD: do NOT call setCustomObjectDetectionRuntimeParameters here.
+    // On SDK 5.2.3 calling this corrupts internal state so that any later
+    // retrieveObjects() or retrieveCustomObjects() returns is_new=false
+    // forever, blocking /obj_det/objects publication. Verified empirically:
+    // both "set + retrieveObjects" and "set + retrieveCustomObjects(rt)"
+    // fail; only passing rt to retrieveCustomObjects() *without* a prior set
+    // call produces detections. The canonical Custom OD sample also follows
+    // this pattern (see ZED SDK samples: object detection/custom detector/
+    //   python/onnx_yolo_internal/custom_internal_detector.py).
 #endif
     mObjDetRtParamsDirty = false;
   }
   // <---- Update runtime parameters only when changed
 
+#if (ZED_SDK_MAJOR_VERSION * 10 + ZED_SDK_MINOR_VERSION) >= 50
+  if (mUsingCustomOd) {
+    sl::CustomObjectDetectionRuntimeParameters custom_rt;
+    custom_rt.object_class_detection_properties = mCustomOdProperties;
+    objDetRes = mZed->retrieveCustomObjects(objects, custom_rt);
+  } else {
+    objDetRes = mZed->retrieveObjects(objects);
+  }
+#else
   objDetRes = mZed->retrieveObjects(objects);
+#endif
 
   if (objDetRes != sl::ERROR_CODE::SUCCESS) {
     RCLCPP_WARN_STREAM(

--- a/zed_components/src/zed_camera/src/zed_camera_component_video_depth.cpp
+++ b/zed_components/src/zed_camera/src/zed_camera_component_video_depth.cpp
@@ -945,7 +945,12 @@ bool ZedCamera::isDepthRequired()
     (mPosTrkMode != sl::POSITIONAL_TRACKING_MODE::GEN_3);
 #endif
 
-  return tot_sub > 0 || depth_required_for_pos_trk;
+  // Object Detection (especially CUSTOM_YOLOLIKE_BOX_OBJECTS) needs depth for
+  // 3D bbox lifting. Without this, grab() runs with enable_depth=false and
+  // the Custom OD inference never produces output (is_new stays false forever).
+  bool depth_required_for_od = mObjDetRunning;
+
+  return tot_sub > 0 || depth_required_for_pos_trk || depth_required_for_od;
 }
 
 void ZedCamera::applyDepthSettings()


### PR DESCRIPTION
## Summary

Three independent bugs prevent `/zed_node/obj_det/objects` from publishing when the user selects `detection_model: 'CUSTOM_YOLOLIKE_BOX_OBJECTS'` on SDK 5.2.3 with a real ZED X camera. Each fix was verified in isolation; only the combination produces detections.

## Reproduction (without this PR)

1. Build the wrapper from current `master` against ZED SDK 5.2.3.
2. Configure `custom_object_detection.yaml` with the upstream sample form, pointing `custom_onnx_file` at a YOLO ONNX (any will do — Ultralytics default `yolo26m.onnx` works).
3. Override `object_detection.od_enabled: true` and `object_detection.detection_model: 'CUSTOM_YOLOLIKE_BOX_OBJECTS'` (e.g. via the `custom_object_detection_config_path` launch arg).
4. Launch the wrapper. The `obj_det/objects` topic is advertised and a subscriber connects.
5. Observed: `obj_det/objects` is silent. `Objects::is_new` is always false. The subscriber count goes 1+ but no messages flow.

Expected: detections at the camera FPS.

## Root causes (and verification matrix)

| Patch combination | `obj_det/objects` rate |
|---|---|
| upstream master | **0 Hz** |
| (1) only | **0 Hz** |
| (1) + (2), keep `retrieveObjects` | **0 Hz** |
| (1) + (3), keep `set...` call | **0 Hz** |
| **(1) + (2) + (3)** | **~25 Hz** ✅ |

### (1) `isDepthRequired()` did not consider OD subscribers

When only `obj_det/objects` has a subscriber (no `depth`, `point_cloud`, `disparity`, `confidence`, or `depth_info` subscribers, no positional tracking that needs depth), `isDepthRequired()` returns false. This causes `grab()` to run with `mRunParams.enable_depth = false`. Custom YOLO depends on stereo depth for 3D bbox lifting, so the inference pipeline produces no output and `Objects::is_new` stays false forever.

**Fix**: include `mObjDetRunning` in the depth-required condition in `isDepthRequired()`.

```diff
+  // Object Detection (especially CUSTOM_YOLOLIKE_BOX_OBJECTS) needs depth for
+  // 3D bbox lifting. Without this, grab() runs with enable_depth=false and
+  // the Custom OD inference never produces output (is_new stays false forever).
+  bool depth_required_for_od = mObjDetRunning;
+
-  return tot_sub > 0 || depth_required_for_pos_trk;
+  return tot_sub > 0 || depth_required_for_pos_trk || depth_required_for_od;
```

### (2) `setCustomObjectDetectionRuntimeParameters()` corrupts SDK state

On SDK 5.2.3, calling `setCustomObjectDetectionRuntimeParameters()` once at runtime appears to leave the Custom OD pipeline in a state where any subsequent `retrieveObjects()` or `retrieveCustomObjects()` returns `is_new=false`. We confirmed empirically that *both* `set + retrieveObjects` and `set + retrieveCustomObjects(rt)` produce zero detections, while skipping the `set` call entirely allows detections to flow.

**Fix**: do not call `setCustomObjectDetectionRuntimeParameters()` for the custom OD path. Per-class runtime parameters are passed via `retrieveCustomObjects(objects, rt)` instead (see (3)).

### (3) `retrieveObjects()` does not pull custom OD results in this configuration

Even with depth enabled and the `set` call removed, the (deprecated-but-recommended-for-SDK-5.x) `retrieveObjects()` never returns custom YOLO detections. Switching to `retrieveCustomObjects(objects, rt)` — passing the runtime params directly each call — matches the canonical Custom OD sample shipped with the SDK and produces detections at the camera FPS.

Reference: `samples/object detection/custom detector/python/onnx_yolo_internal/custom_internal_detector.py`. The official sample uses this exact pattern: no `set...` call, `retrieve_custom_objects(objects, rt)` each frame.

**Fix**: branch on `mUsingCustomOd` and call `retrieveCustomObjects(objects, rt)` for custom OD, leaving the standard `retrieveObjects()` path untouched.

## Hardware / environment

- **Platform**: ZED Box Orin NX, Jetpack 6.4.4, ROS 2 Humble
- **Camera**: ZED X (GMSL)
- **SDK**: 5.2.3
- **Model**: `yolo26m.onnx` (Ultralytics default, COCO 80) — ~78 MB ONNX file with `custom_onnx_input_size: 640` and `custom_class_count: 80`

## Live verification

With the patch applied, a single PET bottle in the camera view yields:

```
ns=bottle id=1 pos=(0.36, -0.14, -0.05)m scale=(0.073, 0.185, 0.073)m conf=91%
```

(Dimensions match the physical bottle within ~5%.)

Three bottles in view simultaneously, each tracked with a stable `label_id` and per-bottle 3D bounding box.

## Notes

- The `set...` call is removed for the custom OD path only. The classic `MULTI_CLASS_BOX*` path is untouched (still uses `setObjectDetectionRuntimeParameters` + `retrieveObjects`).
- The `retrieveCustomObjects` function is documented as deprecated in the header in favour of the `set + retrieveObjects` pattern, but on SDK 5.2.3 only `retrieveCustomObjects(objects, rt)` actually works for custom OD. Worth flagging upstream — either `retrieveCustomObjects` should be undeprecated, or the recommended pattern should be fixed.
- The depth requirement for OD is also true for the standard MULTI_CLASS_BOX models (they also rely on stereo depth), so even without custom OD this fix improves correctness when the only OD consumer subscribes to `obj_det/objects` without separately subscribing to depth.

## Test plan

- [x] Patch applies cleanly to `master` (b47c727)
- [x] `colcon build --packages-select zed_components` succeeds with no warnings
- [x] Standard MULTI_CLASS_BOX OD still works (bool toggling between `mUsingCustomOd=true/false` paths verified by code review; both paths unchanged for the non-custom case)
- [x] Custom OD: 0 detections before patch, ~25 Hz after patch, on real ZED X with yolo26m.onnx
- [x] Three concurrent bottles tracked with stable label_ids
- [ ] Reviewer: apply the patch on your dev box, point `custom_object_detection_config_path` at a YAML with `od_enabled: true` and `detection_model: 'CUSTOM_YOLOLIKE_BOX_OBJECTS'` and verify `ros2 topic hz /zed/zed_node/obj_det/objects` returns a non-zero rate.