### PR TITLE
Add missing publisher options to image_transport publishers

### DIFF
--- a/zed_components/src/zed_camera/src/zed_camera_component_main.cpp
+++ b/zed_components/src/zed_camera/src/zed_camera_component_main.cpp
@@ -9608,7 +9608,7 @@ void ZedCamera::callback_setRoi(
       if (_nitrosDisabled) {
         if (mPubRoiMask.getTopic().empty()) {
           mPubRoiMask = image_transport::create_publisher(
-            this, mRoiMaskTopic, mQos.get_rmw_qos_profile());
+            this, mRoiMaskTopic, mQos.get_rmw_qos_profile(), mPubOpt);
           RCLCPP_INFO_STREAM(
             get_logger(), " * Advertised on topic: "
               << mPubRoiMask.getTopic());

--- a/zed_components/src/zed_camera/src/zed_camera_component_video_depth.cpp
+++ b/zed_components/src/zed_camera/src/zed_camera_component_video_depth.cpp
@@ -217,7 +217,7 @@ void ZedCamera::initVideoDepthPublishers()
       ImageTopicType type = ImageTopicType::IMAGE) {
         ipcPub = create_ipc_pub(topic);
         set_transport_plugins(topic, type);
-        itPub = image_transport::create_publisher(this, topic, qos);
+        itPub = image_transport::create_publisher(this, topic, qos, mPubOpt);
         log_cam_pub(itPub);
       };
 
@@ -330,7 +330,7 @@ void ZedCamera::initVideoDepthPublishers()
   // Lambda to create and log CameraInfo publishers
   auto make_cam_info_pub = [&](const std::string & topic) {
       std::string info_topic = image_transport::getCameraInfoTopic(topic);
-      auto pub = create_publisher<sensor_msgs::msg::CameraInfo>(info_topic, mQos);
+      auto pub = create_publisher<sensor_msgs::msg::CameraInfo>(info_topic, mQos, mPubOpt);
       RCLCPP_INFO_STREAM(get_logger(), " * Advertised on topic: " << pub->get_topic_name());
       return pub;
     };
@@ -338,7 +338,7 @@ void ZedCamera::initVideoDepthPublishers()
   // Lambda to create and log CameraInfo publishers for image_transport or nitros
   auto make_cam_info_trans_pub = [&](const std::string & topic) {
       std::string info_topic = topic + "/camera_info";
-      auto pub = create_publisher<sensor_msgs::msg::CameraInfo>(info_topic, mQos);
+      auto pub = create_publisher<sensor_msgs::msg::CameraInfo>(info_topic, mQos, mPubOpt);
       RCLCPP_INFO_STREAM(get_logger(), " * Advertised on topic: " << pub->get_topic_name());
       return pub;
     };

--- a/zed_components/src/zed_camera_one/src/zed_camera_one_component_video.cpp
+++ b/zed_components/src/zed_camera_one/src/zed_camera_one_component_video.cpp
@@ -274,7 +274,7 @@ void ZedCameraOne::initVideoPublishers()
     ImageTopicType type = ImageTopicType::IMAGE) {
       ipcPub = create_ipc_pub(topic);
       set_transport_plugins(topic, type);
-      itPub = image_transport::create_publisher(this, topic, qos);
+      itPub = image_transport::create_publisher(this, topic, qos, _pubOpt);
       log_cam_pub(itPub);
     };
 
@@ -332,7 +332,7 @@ void ZedCameraOne::initVideoPublishers()
   // Lambda to create and log CameraInfo publishers
   auto make_cam_info_pub = [&](const std::string & topic) {
       std::string info_topic = image_transport::getCameraInfoTopic(topic);
-      auto pub = create_publisher<sensor_msgs::msg::CameraInfo>(info_topic, _qos);
+      auto pub = create_publisher<sensor_msgs::msg::CameraInfo>(info_topic, _qos, _pubOpt);
       RCLCPP_INFO_STREAM(get_logger(), "  * Advertised on topic: " << pub->get_topic_name());
       return pub;
     };
@@ -340,7 +340,7 @@ void ZedCameraOne::initVideoPublishers()
   // Lambda to create and log CameraInfo publishers for image_transport or nitros
   auto make_cam_info_trans_pub = [&](const std::string & topic) {
       std::string info_topic = topic + "/camera_info";
-      auto pub = create_publisher<sensor_msgs::msg::CameraInfo>(info_topic, _qos);
+      auto pub = create_publisher<sensor_msgs::msg::CameraInfo>(info_topic, _qos, _pubOpt);
       RCLCPP_INFO_STREAM(
         get_logger(),
         "  * Advertised on topic: " << pub->get_topic_name());


### PR DESCRIPTION
The publisher options `mPubOpt` allows overriding QoS settings via parameters as described in [ROS 2 Design](https://design.ros2.org/articles/qos_configurability.html). It is curently set in all publishers except for the `image_transport::Publisher`s. Hence, it is currently not possible to configure the QoS settings for images, e.g. to `Best Effort` communication as [recommended for sensor data](https://docs.ros.org/en/rolling/Concepts/Intermediate/About-Quality-of-Service-Settings.html#qos-profiles).

This PR adds the missing publisher options to all `image_transport:Publisher`s.