### PR TITLE
Master.feat/depth rate dynamic param

### DIFF
--- a/zed_components/src/zed_camera/include/zed_camera_component.hpp
+++ b/zed_components/src/zed_camera/include/zed_camera_component.hpp
@@ -341,7 +341,9 @@ protected:
   // <---- Publishing functions
 
   // ----> Utility functions
+  bool isDepthDisabled() { return mDepthDisabledByRate || mDepthDisabledByService || (mDepthMode == sl::DEPTH_MODE::NONE);}
   bool isDepthRequired();
+  void updateDepthRateDisabling();
   bool updatePosTrackingSubscribers(bool force = false);
   bool isPosTrackingRequired();
 
@@ -567,8 +569,11 @@ private:
 #if (ZED_SDK_MAJOR_VERSION * 10 + ZED_SDK_MINOR_VERSION) >= 53
   sl::VoxelMeasureParameters mVoxelParams;
 #endif
-  std::atomic<bool> mDepthDisabled = false;  // Indicates if depth calculation is not required (DEPTH_MODE::NONE)
+  std::atomic<bool> mDepthDisabledByRate = false; // frequently updated depending on mDepthRate
+  std::atomic<bool> mDepthDisabledByService = false; // toggled by enable_depth service
+  std::mutex mDepthTimerMutex;
   int mDepthStabilization = 0;
+  double mDepthRate = 15.0; 
 
   int mCamTimeoutSec = 5;
   int mMaxReconnectTemp = 5;
@@ -968,6 +973,7 @@ private:
 
   // <---- Publisher variables
   sl::Timestamp mSdkGrabTS = 0;
+  sl::Timestamp mSdkDepthGrabTS = 0;
   size_t mRgbSubCount = 0;
   size_t mRgbRawSubCount = 0;
   size_t mRgbGraySubCount = 0;
@@ -1128,6 +1134,7 @@ private:
   std::unique_ptr<sl_tools::WinAvg> mElabPeriodMean_sec;
   std::unique_ptr<sl_tools::WinAvg> mGrabPeriodMean_sec;
   std::unique_ptr<sl_tools::WinAvg> mVideoDepthPeriodMean_sec;
+  std::unique_ptr<sl_tools::WinAvg> mDepthPeriodMean_sec;
   std::unique_ptr<sl_tools::WinAvg> mVideoDepthElabMean_sec;
   std::unique_ptr<sl_tools::WinAvg> mPcPeriodMean_sec;
   std::unique_ptr<sl_tools::WinAvg> mPcProcMean_sec;
@@ -1165,12 +1172,14 @@ private:
   sl_tools::StopWatch mBtFreqTimer;
   sl_tools::StopWatch mPcFreqTimer;
   sl_tools::StopWatch mGnssFixFreqTimer;
+  sl_tools::StopWatch mDepthRateTimer;
 
   int mSysOverloadCount = 0;
   // <---- Diagnostic
 
   // ----> Timestamps
   sl::Timestamp mLastTs_grab = 0;  // Used to calculate stable publish frequency
+  sl::Timestamp mLastTs_depthGrab = 0;
   rclcpp::Time mFrameTimestamp;
   rclcpp::Time mGnssTimestamp;
   rclcpp::Time mLastTs_imu;

--- a/zed_components/src/zed_camera/src/zed_camera_component_bodytrk.cpp
+++ b/zed_components/src/zed_camera/src/zed_camera_component_bodytrk.cpp
@@ -167,7 +167,7 @@ bool ZedCamera::startBodyTracking()
 
   DEBUG_BT("Body Tracking available");
 
-  if (mDepthDisabled) {
+  if (isDepthDisabled()) {
     RCLCPP_WARN(
       get_logger(),
       "Cannot start Body Tracking if Depth processing is disabled");

--- a/zed_components/src/zed_camera/src/zed_camera_component_main.cpp
+++ b/zed_components/src/zed_camera/src/zed_camera_component_main.cpp
@@ -65,7 +65,6 @@ namespace stereolabs
 
 ZedCamera::ZedCamera(const rclcpp::NodeOptions & options)
 : Node("zed_node", options),
-  mDepthDisabled(false),                   // 530
   mStreamingServerRequired(false),         // 647
   mQos(QOS_QUEUE_SIZE),                    // 693
   mThreadStop(false),                      // 954
@@ -87,6 +86,7 @@ ZedCamera::ZedCamera(const rclcpp::NodeOptions & options)
   mBtFreqTimer(get_clock()),               // 1088
   mPcFreqTimer(get_clock()),               // 1089
   mGnssFixFreqTimer(get_clock()),          // 1090
+  mDepthRateTimer(get_clock()),
   mFrameTimestamp(TIMEZERO_ROS),           // 1097
   mGnssTimestamp(TIMEZERO_ROS),            // 1098
   mLastTs_imu(TIMEZERO_ROS),               // 1099
@@ -357,9 +357,9 @@ void ZedCamera::initServices()
 
 #if (ZED_SDK_MAJOR_VERSION * 10 + ZED_SDK_MINOR_VERSION) >= 52
   // With ZED SDK v5.2 we can use Positional Tracking `GEN_3` even if depth is disabled
-  if (!mDepthDisabled || mPosTrkMode == sl::POSITIONAL_TRACKING_MODE::GEN_3) {
+  if (!isDepthDisabled() || mPosTrkMode == sl::POSITIONAL_TRACKING_MODE::GEN_3) {
 #else
-  if (!mDepthDisabled) {
+  if (!isDepthDisabled()) {
 #endif
 
     if (mPosTrackingEnabled) {
@@ -401,7 +401,7 @@ void ZedCamera::initServices()
     }
   }
 
-  if (!mDepthDisabled) {
+  if (!isDepthDisabled()) {
     // Enable Depth Processing
     srv_name = srv_prefix + mSrvEnableDepthName;
     mEnableDepthSrv = create_service<std_srvs::srv::SetBool>(
@@ -603,9 +603,9 @@ void ZedCamera::initParameters()
 #if (ZED_SDK_MAJOR_VERSION * 10 + ZED_SDK_MINOR_VERSION) >= 52
   // With ZED SDK v5.2 we can use Positional Tracking `GEN_3` even if depth is
   // disabled
-  if (!mDepthDisabled || mPosTrkMode == sl::POSITIONAL_TRACKING_MODE::GEN_3) {
+  if (!isDepthDisabled() || mPosTrkMode == sl::POSITIONAL_TRACKING_MODE::GEN_3) {
 #else
-  if (!mDepthDisabled) {
+  if (!isDepthDisabled()) {
 #endif
     // Positional Tracking parameters
     getPosTrackingParams();
@@ -625,7 +625,7 @@ void ZedCamera::initParameters()
     mPublishPath = false;
   }
 
-  if (!mDepthDisabled) {
+  if (!isDepthDisabled()) {
     // Region of Interest parameters
     getRoiParams();
   } else {
@@ -638,7 +638,7 @@ void ZedCamera::initParameters()
     getSensorsParams();
   }
 
-  if (!mDepthDisabled && mPosTrackingEnabled) {
+  if (!isDepthDisabled() && mPosTrackingEnabled) {
     getMappingParams();
   } else {
     mMappingEnabled = false;
@@ -646,9 +646,9 @@ void ZedCamera::initParameters()
 
   // AI PARAMETERS
 #if ((ZED_SDK_MAJOR_VERSION * 10 + ZED_SDK_MINOR_VERSION) < 52)
-  if (!mDepthDisabled && mPosTrackingEnabled) {
+  if (!isDepthDisabled() && mPosTrackingEnabled) {
 #else
-  if (!mDepthDisabled) {
+  if (!isDepthDisabled()) {
 #endif
     if (sl_tools::isObjDetAvailable(mCamUserModel)) {
       getOdParams();
@@ -2274,7 +2274,7 @@ void ZedCamera::setTFCoordFrameNames()
   RCLCPP_INFO_STREAM(
     get_logger(),
     " * Right Optical\t\t-> " << mRightCamOptFrameId);
-  if (!mDepthDisabled) {
+  if (!isDepthDisabled()) {
     RCLCPP_INFO_STREAM(get_logger(), " * Depth\t\t\t-> " << mDepthFrameId);
     RCLCPP_INFO_STREAM(
       get_logger(),
@@ -2406,9 +2406,9 @@ void ZedCamera::initPublishers()
 #if (ZED_SDK_MAJOR_VERSION * 10 + ZED_SDK_MINOR_VERSION) >= 52
   // With ZED SDK v5.2 we can use Positional Tracking `GEN_3` even if depth is
   // disabled
-  if (!mDepthDisabled || mPosTrkMode == sl::POSITIONAL_TRACKING_MODE::GEN_3) {
+  if (!isDepthDisabled() || mPosTrkMode == sl::POSITIONAL_TRACKING_MODE::GEN_3) {
 #else
-  if (!mDepthDisabled) {
+  if (!isDepthDisabled()) {
 #endif
     // ----> Pos Tracking
     if (mPublishOdomPose) {
@@ -2645,7 +2645,7 @@ void ZedCamera::initSubscribers()
   */
   int sub_count = 0;
 
-  if (!mDepthDisabled && mPosTrackingEnabled) {
+  if (!isDepthDisabled() && mPosTrackingEnabled) {
     mClickedPtSub = create_subscription<geometry_msgs::msg::PointStamped>(
       mClickedPtTopic, mQos,
       std::bind(&ZedCamera::callback_clickedPoint, this, _1), mSubOpt);
@@ -3311,7 +3311,7 @@ bool ZedCamera::startCamera()
 
 
   // ----> Set Region of Interest
-  if (!mDepthDisabled) {
+  if (!isDepthDisabled()) {
     if (mAutoRoiEnabled) {
       RCLCPP_INFO(get_logger(), "=== Enabling Automatic ROI ===");
 
@@ -3727,8 +3727,10 @@ bool ZedCamera::startCamera()
   mGrabPeriodMean_sec = std::make_unique<sl_tools::WinAvg>(mCamGrabFrameRate);
   mVideoDepthPeriodMean_sec =
     std::make_unique<sl_tools::WinAvg>(mCamGrabFrameRate);
-  mVideoDepthElabMean_sec =
+  mDepthPeriodMean_sec =
     std::make_unique<sl_tools::WinAvg>(mCamGrabFrameRate);
+  mVideoDepthElabMean_sec =
+    std::make_unique<sl_tools::WinAvg>(mDepthRate);
   mPcPeriodMean_sec = std::make_unique<sl_tools::WinAvg>(mCamGrabFrameRate);
   mPcProcMean_sec = std::make_unique<sl_tools::WinAvg>(mCamGrabFrameRate);
   mObjDetPeriodMean_sec = std::make_unique<sl_tools::WinAvg>(mCamGrabFrameRate);
@@ -3873,7 +3875,7 @@ void ZedCamera::initThreads()
   // <---- Start Video/Depth thread
 
   // ----> Start Pointcloud thread
-  if (!mDepthDisabled) {
+  if (!isDepthDisabled()) {
     mPcDataReady = false;
     mPcThread = std::thread(&ZedCamera::threadFunc_pointcloudElab, this);
   }
@@ -3973,9 +3975,9 @@ bool ZedCamera::startPosTrackingLocked()
 #if (ZED_SDK_MAJOR_VERSION * 10 + ZED_SDK_MINOR_VERSION) >= 52
   // With ZED SDK v5.2 we can use Positional Tracking `GEN_3` even if depth is
   // disabled
-  if (mDepthDisabled && mPosTrkMode != sl::POSITIONAL_TRACKING_MODE::GEN_3) {
+  if (isDepthDisabled() && mPosTrkMode != sl::POSITIONAL_TRACKING_MODE::GEN_3) {
 #else
-  if (mDepthDisabled) {
+  if (isDepthDisabled()) {
 #endif
     RCLCPP_WARN(
       get_logger(),
@@ -4208,7 +4210,7 @@ bool ZedCamera::saveAreaMemoryFile(const std::string & filePath)
 bool ZedCamera::start3dMapping()
 {
   DEBUG_MAP("start3dMapping");
-  if (mDepthDisabled) {
+  if (isDepthDisabled()) {
     RCLCPP_WARN(
       get_logger(),
       "Cannot start 3D Mapping if Depth processing is disabled");
@@ -4992,6 +4994,8 @@ void ZedCamera::threadFunc_zedGrab()
 
       sl_tools::StopWatch grabElabTimer(get_clock());
 
+      updateDepthRateDisabling();
+
       // ----> Apply depth settings
       DEBUG_STREAM_GRAB("Grab thread: applying depth settings");
       applyDepthSettings();
@@ -5030,7 +5034,7 @@ void ZedCamera::threadFunc_zedGrab()
       }
       // ----> Check for Positional Tracking requirement
 
-      if (!mDepthDisabled) {
+      if (!isDepthDisabled()) {
         // ----> Check for Spatial Mapping requirement
 
         DEBUG_STREAM_GRAB("Grab thread: checking Spatial Mapping requirement");
@@ -5121,7 +5125,10 @@ void ZedCamera::threadFunc_zedGrab()
 
         } else {
           DEBUG_GRAB("Grab thread: reading...");
-          mGrabStatus = mZed->read();  // Image and sensor data reading with no depth processing
+          mRunParams.enable_depth = false;
+          mGrabStatus = mZed->grab(mRunParams);
+          mRunParams.enable_depth = true;
+          //mGrabStatus = mZed->read();  // Image and sensor data reading with no depth processing
         }
       }
       // <---- Safe grab
@@ -5326,7 +5333,7 @@ void ZedCamera::threadFunc_zedGrab()
       processVideoDepth();
       // <---- Retrieve Image/Depth data if someone has subscribed to
 
-      if (!mDepthDisabled) {
+      if (!isDepthDisabled()) {
         // ----> Retrieve the point cloud if someone has subscribed to
         DEBUG_STREAM_GRAB("Grab thread: retrieving Point Cloud data");
         processPointCloud();
@@ -5335,9 +5342,9 @@ void ZedCamera::threadFunc_zedGrab()
 
 #if (ZED_SDK_MAJOR_VERSION * 10 + ZED_SDK_MINOR_VERSION) >= 52
       // With ZED SDK v5.2 we can use `GEN_3` even if depth is disabled
-      if (!mDepthDisabled || mPosTrkMode == sl::POSITIONAL_TRACKING_MODE::GEN_3) {
+      if (!isDepthDisabled() || mPosTrkMode == sl::POSITIONAL_TRACKING_MODE::GEN_3) {
 #else
-      if (!mDepthDisabled) {
+      if (!isDepthDisabled()) {
 #endif
         // ----> Localization processing
         DEBUG_STREAM_GRAB("Grab thread: Localization processing");
@@ -5382,7 +5389,7 @@ void ZedCamera::threadFunc_zedGrab()
         // <---- Localization processing
       }
 
-      if (!mDepthDisabled) {
+      if (!isDepthDisabled()) {
         DEBUG_STREAM_GRAB("Grab thread: Object Detection processing");
         {
           std::lock_guard<std::mutex> lock(mObjDetMutex);
@@ -5815,9 +5822,9 @@ void ZedCamera::publishTFs(rclcpp::Time t)
 #if (ZED_SDK_MAJOR_VERSION * 10 + ZED_SDK_MINOR_VERSION) >= 52
   // With ZED SDK v5.2 we can use Positional Tracking `GEN_3` even if depth is
   // disabled
-  if (!mDepthDisabled || mPosTrkMode == sl::POSITIONAL_TRACKING_MODE::GEN_3) {
+  if (!isDepthDisabled() || mPosTrkMode == sl::POSITIONAL_TRACKING_MODE::GEN_3) {
 #else
-  if (!mDepthDisabled) {
+  if (!isDepthDisabled()) {
 #endif
     if (mPublishTF) {
       publishOdomTF(t); // publish the base Frame in odometry frame
@@ -7473,9 +7480,9 @@ bool ZedCamera::isPosTrackingRequired()
 #if (ZED_SDK_MAJOR_VERSION * 10 + ZED_SDK_MINOR_VERSION) >= 52
   // With ZED SDK v5.2 we can use Positional Tracking `GEN_3` even if depth is
   // disabled
-  if (mDepthDisabled && mPosTrkMode != sl::POSITIONAL_TRACKING_MODE::GEN_3) {
+  if (isDepthDisabled() && mPosTrkMode != sl::POSITIONAL_TRACKING_MODE::GEN_3) {
 #else
-  if (mDepthDisabled) {
+  if (isDepthDisabled()) {
 #endif
     DEBUG_ONCE_PT("POS. TRACKING not required: Depth disabled (unless GEN3 mode).");
     return false;
@@ -8006,20 +8013,20 @@ void ZedCamera::callback_enableDepth(
 
   if (req->data) {
     RCLCPP_INFO(get_logger(), "Depth processing enabled");
-    mDepthDisabled = false;
+    mDepthDisabledByService = false;
     res->message = "Depth processing enabled";
   } else {
     RCLCPP_INFO(get_logger(), "Depth processing disabled");
-    mDepthDisabled = true;
+    mDepthDisabledByService = true;
     res->message = "Depth processing disabled";
   }
 
 #if (ZED_SDK_MAJOR_VERSION * 10 + ZED_SDK_MINOR_VERSION) >= 52
   // With ZED SDK v5.2 we can use Positional Tracking `GEN_3` even if depth is
   // disabled
-  if (mDepthDisabled && mPosTrkMode != sl::POSITIONAL_TRACKING_MODE::GEN_3) {
+  if (isDepthDisabled() && mPosTrkMode != sl::POSITIONAL_TRACKING_MODE::GEN_3) {
 #else
-  if (mDepthDisabled) {
+  if (isDepthDisabled()) {
 #endif
     RCLCPP_WARN(
       get_logger(),
@@ -8031,13 +8038,13 @@ void ZedCamera::callback_enableDepth(
     }
   }
 
-  if (mDepthDisabled && mObjDetEnabled) {
+  if (isDepthDisabled() && mObjDetEnabled) {
     RCLCPP_WARN(
       get_logger(),
       "Depth disabled: Object Detection processing will be disabled.");
   }
 
-  if (mDepthDisabled && mBodyTrkEnabled) {
+  if (isDepthDisabled() && mBodyTrkEnabled) {
     RCLCPP_WARN(
       get_logger(),
       "Depth disabled: Body Tracking processing will be disabled.");
@@ -8695,10 +8702,10 @@ void ZedCamera::callback_updateDiagnostic(
       stat.addf(
         "Data Capture -capped-", "%.1f Hz (%.1f%%)", freq, freq_perc);
     } else {
-      stat.addf("Camera Grab rate", "%d Hz", mCamGrabFrameRate);
+      stat.addf("Desired Camera Grab rate", "%d Hz", mCamGrabFrameRate);
       freq_perc = 100. * freq / mCamGrabFrameRate;
       stat.addf(
-        "Data Capture", "Mean Frequency: %.1f Hz (%.1f%%)", freq,
+        "Actual Camera Grab rate", "Mean Frequency: %.1f Hz (%.1f%%)", freq,
         freq_perc);
     }
 
@@ -8752,26 +8759,31 @@ void ZedCamera::callback_updateDiagnostic(
       stat.add("Input mode", "Live Camera");
     }
 
+    bool shouldPublishDepthDiagnostics = 
+      !mDepthDisabledByService
+      && mDepthMode != sl::DEPTH_MODE::NONE
+      && mDepthRate != 0.0;
+
     if (mVdPublishing) {
       if (mSvoMode && !mSvoRealtime) {
         freq = 1. / mGrabPeriodMean_sec->getAvg();
         freq_perc = 100. * freq / mVdPubRate;
         stat.addf(
-          "Video/Depth", "Mean Frequency: %.1f Hz (%.1f%%)", freq,
+          "Depth", "Mean Frequency: %.1f Hz (%.1f%%)", freq,
           freq_perc);
-      } else {
-        freq = 1. / mVideoDepthPeriodMean_sec->getAvg();
-        freq_perc = 100. * freq / mVdPubRate;
-        frame_grab_period = 1. / mVdPubRate;
+      } else if (shouldPublishDepthDiagnostics) {
+        freq = 1. / mDepthPeriodMean_sec->getAvg();
+        freq_perc = 100. * freq / mDepthRate;
+        frame_grab_period = 1. / mDepthRate;
         stat.addf(
-          "Video/Depth", "Mean Frequency: %.1f Hz (%.1f%%)", freq,
+          "Depth", "Mean Frequency: %.1f Hz (%.1f%%)", freq,
           freq_perc);
       }
       stat.addf(
         "Video/Depth", "Processing Time: %.6f sec (Max. %.3f sec)",
         mVideoDepthElabMean_sec->getAvg(), frame_grab_period);
     } else {
-      stat.add("Video/Depth", "Topic not subscribed");
+      stat.add("Depth", "Topic not subscribed");
     }
 
     if (mSvoMode) {
@@ -8790,7 +8802,7 @@ void ZedCamera::callback_updateDiagnostic(
       }
     }
 
-    if (!mDepthDisabled) {
+    if (shouldPublishDepthDiagnostics) {
       stat.add("Depth status", "ACTIVE");
       stat.add("Depth mode", sl::toString(mDepthMode).c_str());
 
@@ -8863,9 +8875,9 @@ void ZedCamera::callback_updateDiagnostic(
     }
 
 #if (ZED_SDK_MAJOR_VERSION * 10 + ZED_SDK_MINOR_VERSION) >= 52
-    if (!mDepthDisabled || mPosTrkMode == sl::POSITIONAL_TRACKING_MODE::GEN_3) { // With ZED SDK v5.2 we can use `GEN_3` even if depth is disabled
+    if (!isDepthDisabled() || mPosTrkMode == sl::POSITIONAL_TRACKING_MODE::GEN_3) { // With ZED SDK v5.2 we can use `GEN_3` even if depth is disabled
 #else
-    if (!mDepthDisabled) {
+    if (!isDepthDisabled()) {
 #endif
       stat.addf(
         "Positional Tracking mode", "%s",
@@ -9652,7 +9664,7 @@ void ZedCamera::callback_setRoi(
 
   RCLCPP_INFO(get_logger(), "** Set ROI service called **");
 
-  if (mDepthDisabled) {
+  if (isDepthDisabled()) {
     std::string err_msg =
       "Error while setting ZED SDK region of interest: depth processing is "
       "disabled!";
@@ -9783,7 +9795,7 @@ void ZedCamera::callback_resetRoi(
 {
   RCLCPP_INFO(get_logger(), "** Reset ROI service called **");
 
-  if (mDepthDisabled) {
+  if (isDepthDisabled()) {
     std::string err_msg =
       "Error while resetting ZED SDK region of interest: depth processing "
       "is "

--- a/zed_components/src/zed_camera/src/zed_camera_component_main.cpp
+++ b/zed_components/src/zed_camera/src/zed_camera_component_main.cpp
@@ -3970,11 +3970,6 @@ bool ZedCamera::startPosTrackingLocked()
 {
   // Caller must hold mPtMutex.
 
-  //EMILIS
-  if (!mPosTrackingEnabled) {
-    return false;
-  }
-
 #if (ZED_SDK_MAJOR_VERSION * 10 + ZED_SDK_MINOR_VERSION) >= 52
   // With ZED SDK v5.2 we can use Positional Tracking `GEN_3` even if depth is
   // disabled
@@ -5147,7 +5142,7 @@ void ZedCamera::threadFunc_zedGrab()
             rclcpp::sleep_for(
               std::chrono::microseconds(
                 static_cast<int>(mGrabPeriodMean_sec->getAvg() * 1e6)));
-            if (mResetPoseWithSvoLoop) {
+            if (mPosTrackingEnabled && mResetPoseWithSvoLoop) {
               RCLCPP_WARN(
                 get_logger(),
                 " * Camera pose reset to initial conditions.");
@@ -9752,7 +9747,7 @@ void ZedCamera::callback_setRoi(
             nvidia::isaac_ros::nitros::ManagedNitrosPublisher<
               nvidia::isaac_ros::nitros::NitrosImage>>(
             this, mRoiMaskTopic,
-            nvidia::isaac_ros::nitros::nitros_image_bgra8_t::
+            nvidia::isaac_ros::nitros::nitros_image_rgb8_t::
             supported_type_name,
             nvidia::isaac_ros::nitros::NitrosDiagnosticsConfig(), mQos);
           RCLCPP_INFO_STREAM(

--- a/zed_components/src/zed_camera/src/zed_camera_component_main.cpp
+++ b/zed_components/src/zed_camera/src/zed_camera_component_main.cpp
@@ -3970,6 +3970,11 @@ bool ZedCamera::startPosTrackingLocked()
 {
   // Caller must hold mPtMutex.
 
+  //EMILIS
+  if (!mPosTrackingEnabled) {
+    return false;
+  }
+
 #if (ZED_SDK_MAJOR_VERSION * 10 + ZED_SDK_MINOR_VERSION) >= 52
   // With ZED SDK v5.2 we can use Positional Tracking `GEN_3` even if depth is
   // disabled

--- a/zed_components/src/zed_camera/src/zed_camera_component_objdet.cpp
+++ b/zed_components/src/zed_camera/src/zed_camera_component_objdet.cpp
@@ -948,7 +948,7 @@ bool ZedCamera::startObjDetect()
     return false;
   }
 
-  if (mDepthDisabled) {
+  if (isDepthDisabled()) {
     RCLCPP_WARN(
       get_logger(),
       "Cannot start Object Detection if "

--- a/zed_components/src/zed_camera/src/zed_camera_component_video_depth.cpp
+++ b/zed_components/src/zed_camera/src/zed_camera_component_video_depth.cpp
@@ -268,7 +268,7 @@ void ZedCamera::initVideoDepthPublishers()
       }
     }
 
-    if (!mDepthDisabled) {
+    if (!isDepthDisabled()) {
       if (mPublishImgRoiMask && (mAutoRoiEnabled || mManualRoiEnabled)) {
         create_dual_pub(mRoiMaskTopic, mPubIpcRoiMask, mPubRoiMask);
       }
@@ -416,7 +416,7 @@ void ZedCamera::initVideoDepthPublishers()
   // <---- Camera Info publishers
 
   // ----> Other depth-related publishers
-  if (!mDepthDisabled) {
+  if (!isDepthDisabled()) {
     if (mPublishDepthInfo) {
       mPubDepthInfo = create_publisher<zed_msgs::msg::DepthInfoStamped>(
         mDepthInfoTopic, mQos, mPubOpt);
@@ -608,14 +608,14 @@ void ZedCamera::getDepthParams()
   }
 
   if (mDepthMode == sl::DEPTH_MODE::NONE) {
-    mDepthDisabled = true;
+    //mDepthDisabled = true;
     mDepthStabilization = 0;
     RCLCPP_INFO_STREAM(
       get_logger(),
       " * Depth mode: " << sl::toString(mDepthMode).c_str()
                         << " - DEPTH DISABLED");
   } else {
-    mDepthDisabled = false;
+    //mDepthDisabled = false;
     RCLCPP_INFO_STREAM(
       get_logger(),
       " * Depth mode: " << sl::toString(mDepthMode).c_str()
@@ -623,7 +623,7 @@ void ZedCamera::getDepthParams()
                         << "]");
   }
 
-  if (!mDepthDisabled) {
+  if (!isDepthDisabled()) {
 #if ((ZED_SDK_MAJOR_VERSION * 10 + ZED_SDK_MINOR_VERSION) < 51)
     const double default_min_depth = 0.1;
 #else
@@ -642,6 +642,14 @@ void ZedCamera::getDepthParams()
       mDepthStabilization, mDepthStabilization,
       " * Depth Stabilization: ", false, -1, 100);
     // -1 means use SDK default (mInitParams keeps its constructed default value)
+
+    sl_tools::getParam(
+      shared_from_this(), "depth.depth_freq",
+      mDepthRate, mDepthRate,
+      " * Depth Rate: ", true, -1.0, static_cast<double>(mCamGrabFrameRate));
+    if (mDepthRate <= 0.0) {
+      mDepthRate = static_cast<double>(mCamGrabFrameRate);
+    }
 
     if (_nitrosDisabled) {
       sl_tools::getParam(
@@ -927,11 +935,12 @@ bool ZedCamera::updateVideoDepthSubscribers(bool force)
   constexpr auto kSubQueryInterval = std::chrono::milliseconds(200);
   auto now = std::chrono::steady_clock::now();
 
-  if (!force && mVideoDepthSubCountInit &&
-    (now - mLastVideoDepthSubCountQuery) < kSubQueryInterval)
-  {
-    return true;
-  }
+
+  //if (!force && mVideoDepthSubCountInit &&
+  //  (now - mLastVideoDepthSubCountQuery) < kSubQueryInterval)
+  //{
+  //  return true;
+  //}
 
   mLastVideoDepthSubCountQuery = now;
   mVideoDepthSubCountInit = true;
@@ -1030,7 +1039,7 @@ bool ZedCamera::updateVideoDepthSubscribers(bool force)
     }
 
 
-    if (!mDepthDisabled) {
+    if (!isDepthDisabled()) {
       if (_nitrosDisabled) {
         if (mPublishDepthMap) {
           mDepthSubCount = mPubDepth.getNumSubscribers() + ipc_sub_count(mPubIpcDepth);
@@ -1070,11 +1079,30 @@ bool ZedCamera::updateVideoDepthSubscribers(bool force)
   return true;
 }
 
+void ZedCamera::updateDepthRateDisabling()
+{
+  // Units are seconds for all variables
+  if (mDepthRate == mCamGrabFrameRate) { mDepthDisabledByRate = false; return; }
+  if (mDepthRate <= 0.0) { mDepthDisabledByRate = true; return; }
+  
+  static double carry = 0.0;
+  double targetPeriod(1.0 / mDepthRate);
+
+  double toc = mDepthRateTimer.toc();
+  if (toc + carry >= targetPeriod) {
+    carry = std::min(toc + carry - targetPeriod, targetPeriod);
+    mDepthRateTimer.tic();
+    mDepthDisabledByRate = false;
+    return;
+  }
+  mDepthDisabledByRate = true;
+}
+
 bool ZedCamera::isDepthRequired()
 {
   // DEBUG_STREAM_COMM( "isDepthRequired called");
 
-  if (mDepthDisabled) {
+  if (isDepthDisabled()) {
     DEBUG_STREAM_COMM("Depth not required: depth disabled");
     return false;
   }
@@ -1688,6 +1716,10 @@ void ZedCamera::retrieveVideoDepth(bool gpu)
 
   if (retrieved_video) {
     DEBUG_STREAM_VD(" *** Video Data retrieved ***");
+    mSdkGrabTS = mZed->getTimestamp(sl::TIME_REFERENCE::IMAGE);
+    auto now = mZed->getTimestamp(sl::TIME_REFERENCE::CURRENT);
+    DEBUG_STREAM_VD(
+      " * Video Latency: " << static_cast<double>(now - mSdkGrabTS) * 1e-9 << " sec");
   }
 
   DEBUG_STREAM_VD(" *** Retrieving Depth Data ***");
@@ -1698,13 +1730,10 @@ void ZedCamera::retrieveVideoDepth(bool gpu)
 
   if (retrieved_depth) {
     DEBUG_STREAM_VD(" *** Depth Data retrieved ***");
-  }
-
-  if (retrieved_video || retrieved_depth) {
-    mSdkGrabTS = mZed->getTimestamp(sl::TIME_REFERENCE::IMAGE);
+    mSdkDepthGrabTS = mZed->getTimestamp(sl::TIME_REFERENCE::IMAGE);
     auto now = mZed->getTimestamp(sl::TIME_REFERENCE::CURRENT);
     DEBUG_STREAM_VD(
-      " * Video/Depth Latency: " << static_cast<double>(now - mSdkGrabTS) * 1e-9 << " sec");
+      " * Depth Latency: " << static_cast<double>(now - mSdkDepthGrabTS) * 1e-9 << " sec");
   }
 
   DEBUG_VD(" *** Retrieving Video/Depth Data DONE ***");
@@ -1930,7 +1959,7 @@ void ZedCamera::publishVideoDepth(rclcpp::Time & out_pub_ts)
   DEBUG_VD("=== Publish Video and Depth topics === ");
   sl_tools::StopWatch vdElabTimer(get_clock());
 
-  checkRgbDepthSync();
+  //checkRgbDepthSync(); // This doesn't work when we are altering depth rate
 
   vdElabTimer.tic();
   rclcpp::Time timeStamp;
@@ -1979,7 +2008,7 @@ void ZedCamera::checkRgbDepthSync()
       RCLCPP_WARN_STREAM(
         get_logger(),
         " !!!!! DEPTH/RGB ASYNC !!!!! - Delta: "
-          << 1e-9 * static_cast<double>(ts_depth - ts_rgb)
+          << 1e-9 * static_cast<int64_t>(ts_depth.data_ns - ts_rgb.data_ns) 
           << " sec");
       RCLCPP_WARN(
         get_logger(),
@@ -2017,8 +2046,19 @@ bool ZedCamera::checkGrabAndUpdateTimestamp(rclcpp::Time & out_pub_ts)
           << 1. / mVideoDepthPeriodMean_sec->getAvg() << " Hz / Expected: " << 1. / mVdPubRate <<
           " sec @" << mVdPubRate <<
           " Hz");
+
       mLastTs_grab = mSdkGrabTS;
     }
+  }
+
+  if (mSdkDepthGrabTS.getNanoseconds() != mLastTs_depthGrab.getNanoseconds()
+      && mSdkDepthGrabTS.data_ns != 0 
+      && !mSvoMode) {
+    double period_sec =
+      static_cast<double>(mSdkDepthGrabTS.data_ns - mLastTs_depthGrab.data_ns) / 1e9;
+
+    mDepthPeriodMean_sec->addValue(period_sec);
+    mLastTs_depthGrab = mSdkDepthGrabTS;
   }
 
   if (mSvoMode) {
@@ -3509,6 +3549,29 @@ bool ZedCamera::handleDepthParams(
       val = static_cast<double>(mCamGrabFrameRate);
     }
     mPcPubRate = val;
+    DEBUG_STREAM_DYN_PARAMS("Parameter '" << name << "' correctly set to " << val);
+    return true;
+  } else if (name == "depth.depth_freq") {
+    rclcpp::ParameterType correctType = rclcpp::ParameterType::PARAMETER_DOUBLE;
+    if (param.get_type() != correctType) {
+      result.successful = false;
+      result.reason = name + " must be a " + rclcpp::to_string(correctType);
+      RCLCPP_WARN_STREAM(get_logger(), result.reason);
+      return true;
+    }
+     double val = param.as_double();
+    if (val < -1.0 || val > mCamGrabFrameRate) {
+      result.successful = false;
+      result.reason = name + " must be >= -1 and <= `grab_frame_rate` (0 or -1 = no limit)";
+      RCLCPP_WARN_STREAM(get_logger(), result.reason);
+      return true;
+    if (val <= 0.0) {
+      val = static_cast<double>(mCamGrabFrameRate);
+    }
+    }
+    mDepthRate = val;
+    // Also need to update the window for the diagnostics (so diagnostics refresh per second)
+    mDepthPeriodMean_sec->setNewSize(mDepthRate);
     DEBUG_STREAM_DYN_PARAMS("Parameter '" << name << "' correctly set to " << val);
     return true;
   } else if (name == "depth.depth_confidence" || name == "depth.depth_texture_conf") {

--- a/zed_components/src/zed_camera/src/zed_camera_component_video_depth.cpp
+++ b/zed_components/src/zed_camera/src/zed_camera_component_video_depth.cpp
@@ -292,7 +292,7 @@ void ZedCamera::initVideoDepthPublishers()
     auto make_nitros_img_pub = [&](const std::string & topic) {
         auto ret = std::make_shared<nvidia::isaac_ros::nitros::ManagedNitrosPublisher<
               nvidia::isaac_ros::nitros::NitrosImage>>(
-          this, topic, nvidia::isaac_ros::nitros::nitros_image_bgra8_t::supported_type_name,
+          this, topic, nvidia::isaac_ros::nitros::nitros_image_rgb8_t::supported_type_name,
           nvidia::isaac_ros::nitros::NitrosDiagnosticsConfig(), mQos);
         RCLCPP_INFO_STREAM(get_logger(), " * Advertised on topic: " << topic);
         RCLCPP_INFO_STREAM(get_logger(), " * Advertised on topic: " << topic + "/nitros");
@@ -2530,11 +2530,11 @@ void ZedCamera::publishImageWithInfo(
     header.stamp = mUsePubTimestamps ? get_clock()->now() : t;
     header.frame_id = imgFrameId;
 
-    auto encoding = img_encodings::BGRA8; // Default encoding
+    auto encoding = img_encodings::RGBA8; // Default encoding
     if (img.getDataType() == sl::MAT_TYPE::U8_C1) {
       encoding = img_encodings::MONO8; // Mono image
     } else if (img.getDataType() == sl::MAT_TYPE::U8_C3) {
-      encoding = img_encodings::BGR8; // BGR image
+      encoding = img_encodings::RGB8; // BGR image
     } else if (img.getDataType() == sl::MAT_TYPE::F32_C1) {
       encoding = img_encodings::TYPE_32FC1; // Float image
     }


### PR DESCRIPTION
Added depth frequency as a dynamic parameter. From our zed config file, set `depth.depth_freq`to desired grab frequency. Note that this bound from above by the camera frame rate and is itself an upper bound for the existing `depth.point_cloud_freq` parameter.

Also did related changes to the /diagnostics topic that now prints the depth rate.